### PR TITLE
apply workunit metadata as attributes to otel spans

### DIFF
--- a/src/python/shoalsoft/pants_telemetry_plugin/workunit_handler.py
+++ b/src/python/shoalsoft/pants_telemetry_plugin/workunit_handler.py
@@ -63,7 +63,7 @@ class TelemetryWorkunitsCallback(WorkunitsCallback):
             description=raw_workunit.get("description"),
             start_time=start_time,
             end_time=end_time,
-            metadata=FrozenDict(raw_workunit.get("metadata", {})),
+            metadata=FrozenDict.deep_freeze(raw_workunit.get("metadata", {})),
         )
 
     def __call__(


### PR DESCRIPTION
Apply workunit level and metadata as attributes on generated OpenTelemetry spans. The attributes are prefixed with `pantsbuild.workunit` as a namespace. The metadata dictionary is flattened into OpenTelemetry attributes with keys emitted as `pantsbuild.workunit.metdata.KEY` attribitues. Only primitive values are handled currently.

Also a bug in construction of the `FrozenDict` used for workunit metadata since complex values were not "deeply" frozen.