### PR TITLE
avoid setting a global `TracerProvider`

### DIFF
--- a/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry.py
@@ -190,8 +190,8 @@ def get_processor(
             SERVICE_NAME: "pantsbuild",
         }
     )
-    trace.set_tracer_provider(TracerProvider(sampler=sampling.ALWAYS_ON, resource=resource))
-    tracer = trace.get_tracer(__name__)
+    tracer_provider = TracerProvider(sampler=sampling.ALWAYS_ON, resource=resource)
+    tracer = tracer_provider.get_tracer(__name__)
 
     span_exporter: SpanExporter
     if span_exporter_name == TracingExporterId.JSON_FILE:
@@ -214,7 +214,7 @@ def get_processor(
         )
 
     span_processor = BatchSpanProcessor(span_exporter)
-    trace.get_tracer_provider().add_span_processor(span_processor)  # type: ignore[attr-defined]
+    tracer_provider.add_span_processor(span_processor)
 
     otel_processor = OpenTelemetryProcessor(
         tracer=tracer, span_processor=span_processor, traceparent_env_var=traceparent_env_var


### PR DESCRIPTION
As described in https://github.com/shoalsoft/shoalsoft-pants-opentelemetry-plugin/issues/51, the OpenTelemetry library is warning that the plugin is trying to override a previously-set `TracerProvider`. There is no need to do that for this plugin given how it interacts with OpenTelemetry. Avoid using the global `set_tracer_provider` API.

Fixes https://github.com/shoalsoft/shoalsoft-pants-opentelemetry-plugin/issues/51
