### PR TITLE
release v0.2.0.dev2

### DIFF
--- a/src/python/shoalsoft/pants_opentelemetry_plugin/BUILD
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PLUGIN_VERSION = "0.2.0.dev1"
+PLUGIN_VERSION = "0.2.0.dev2"
 
 PANTS_MAJOR_MINOR_VERSIONS = ["2.27", "2.26", "2.25"]
 


### PR DESCRIPTION
Release v0.2.0.dev2 with fixes for https://github.com/shoalsoft/shoalsoft-pants-opentelemetry-plugin/issues/11 and https://github.com/shoalsoft/shoalsoft-pants-opentelemetry-plugin/issues/51.