### PR TITLE
set markdown content type for PyPI description

### DIFF
--- a/src/python/shoalsoft/pants_opentelemetry_plugin/BUILD
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/BUILD
@@ -143,6 +143,7 @@ python_distribution(
         name="shoalsoft-pants-opentelemetry-plugin",
         description=f"Pantsbuild OpenTelemetry Plugin from Shoal Software LLC",
         long_description=LONG_DESCRIPTION,
+        long_description_content_type="text/markdown",
         python_requires=f"==3.11.*",
         version=PLUGIN_VERSION,
         author="Tom Dyas",


### PR DESCRIPTION
Explicitly set the content type for the PyPI long description to `text/markdown` so it is rendered correctly on PyPI. Tested by uploading a wheel to `test.pypi.org` and verifying the description renders correctly.