### PR TITLE
add name to exception logging processor

### DIFF
--- a/src/python/shoalsoft/pants_opentelemetry_plugin/exception_logging_processor.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/exception_logging_processor.py
@@ -30,8 +30,9 @@ logger = logging.getLogger(__name__)
 
 
 class ExceptionLoggingProcessor(Processor):
-    def __init__(self, processor: Processor) -> None:
+    def __init__(self, processor: Processor, *, name: str) -> None:
         self._processor = processor
+        self._name = name
         self._exception_count = 0
 
     @contextmanager
@@ -40,12 +41,12 @@ class ExceptionLoggingProcessor(Processor):
             return (yield)
         except Exception as ex:
             logger.debug(
-                f"An exception occurred while processing a workunit in the OpenTelemetry handler: {ex}",
+                f"An exception occurred while processing a workunit in the {self._name} workunit tracing handler: {ex}",
                 exc_info=True,
             )
             if self._exception_count == 0:
                 logger.warning(
-                    "Ignored an exception from the OpenTelemetry tracing handler. These esceptions will be logged "
+                    f"Ignored an exception from the {self._name} workunit tracing handler. These exceptions will be logged "
                     "at DEBUG level. No further warnings will be logged."
                 )
             self._exception_count += 1
@@ -69,5 +70,5 @@ class ExceptionLoggingProcessor(Processor):
             self._processor.finish(timeout=timeout, context=context)
         if self._exception_count > 1:
             logger.warning(
-                f"Ignored {self._exception_count} exceptions from the OpenTelemetry tracing handler."
+                f"Ignored {self._exception_count} exceptions from the {self._name} workunit tracing handler."
             )

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/exception_logging_processor_test.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/exception_logging_processor_test.py
@@ -83,7 +83,7 @@ def workunit(incomplete_workunit: IncompleteWorkunit) -> Workunit:
 def test_exception_logging_proessor(
     incomplete_workunit: IncompleteWorkunit, workunit: Workunit, caplog
 ) -> None:
-    processor = ExceptionLoggingProcessor(AlwaysRaisesExceptionProcessor())
+    processor = ExceptionLoggingProcessor(AlwaysRaisesExceptionProcessor(), name="test")
     context = MockProcessorContext()
 
     assert len(caplog.record_tuples) == 0
@@ -120,7 +120,7 @@ def test_exceptions_logged_at_debug_level(
     """With logging level set to DEBUG, exceptions should now be logged at
     DEBUG level."""
 
-    processor = ExceptionLoggingProcessor(AlwaysRaisesExceptionProcessor())
+    processor = ExceptionLoggingProcessor(AlwaysRaisesExceptionProcessor(), name="test")
     context = MockProcessorContext()
 
     with caplog.at_level(logging.DEBUG):

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/register.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/register.py
@@ -61,7 +61,9 @@ async def telemetry_workunits_callback_factory_request(
             traceparent_env_var=traceparent_env_var,
         )
 
-        processor = SingleThreadedProcessor(ExceptionLoggingProcessor(otel_processor))
+        processor = SingleThreadedProcessor(
+            ExceptionLoggingProcessor(otel_processor, name="OpenTelemetry")
+        )
         processor.initialize()
 
     finish_timeout = datetime.timedelta(seconds=telemetry.finish_timeout)


### PR DESCRIPTION
Add a `name` attribute to `ExceptionLoggingProcessor` to avoid hard-coding "OpenTelemetry." This is mainly to facilitate reuse in another project.