### PR TITLE
add GHA workflow for PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,11 +29,11 @@ jobs:
           gh release download --dir=assets --pattern='shoalsoft*' ${{ github.event.inputs.release_tag }}
         env:
           GH_TOKEN: ${{ github.token }}
-        - name: Publish package distributions to TestPyPI
-          uses: pypa/gh-action-pypi-publish@release/v1
-          with:
-            packages-dir: assets/
-            repository-url: https://test.pypi.org/legacy/
+      - name: Publish package distributions to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: assets/
+          repository-url: https://test.pypi.org/legacy/
 
   pypi-publish:
     name: Upload release to PyPI
@@ -49,7 +49,7 @@ jobs:
           gh release download --dir=assets --pattern='shoalsoft*' ${{ github.event.inputs.release_tag }}
         env:
           GH_TOKEN: ${{ github.token }}
-        - name: Publish package distributions to TestPyPI
-          uses: pypa/gh-action-pypi-publish@release/v1
-          with:
-            packages-dir: assets/
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: assets/

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,9 +15,29 @@ on:
         type: boolean
 
 jobs:
+  validate-release:
+    name: Validate the release before distribution.
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Validate the release.
+        run: |
+          gh release view "$RELEASE_TAG" --json=assets,isDraft > release-info.json
+          if [ "$(cat release-info.json | jq .isDraft)" != "false" ]; then
+            echo "ERROR: Release $RELEASE_TAG is still in draft mode." 1>&2
+            exit 1
+          fi
+          if [ "$(cat release-info.json | jq '[.assets[] | select(.name | startswith("shoalsoft_"))] | length')"" != "2" ]; then
+            echo "ERROR: Release $RELEASE_TAG does not have contain all of the expected assets." 1>&2
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+
   testpypi-publish:
     name: Upload release to TestPyPI
     if: github.event.inputs.publish_to_testpypi
+    needs: validate-release
     runs-on: ubuntu-24.04
     environment: testpypi
     permissions:
@@ -38,6 +58,7 @@ jobs:
   pypi-publish:
     name: Upload release to PyPI
     if: github.event.inputs.publish_to_pypi
+    needs: validate-release
     runs-on: ubuntu-24.04
     environment: pypi
     permissions:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,52 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+        description: 'The release to publish to PyPI'
+      publish_to_pypi:
+        required: true
+        type: boolean
+      publish_to_testpypi:
+        required: true
+        type: boolean
+
+jobs:
+  testpypi-publish:
+    name: Upload release to TestPyPI
+    if: github.event.inputs.publish_to_testpypi
+    runs-on: ubuntu-24.04
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download the wheel and source archive from the draft release.
+        run: |
+          mkdir -p assets
+          gh release download --dir=assets --pattern='shoalsoft' ${{ github.event.inputs.release_tag }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        - name: Publish package distributions to TestPyPI
+          uses: pypa/gh-action-pypi-publish@release/v1
+          with:
+            repository-url: https://test.pypi.org/legacy/
+
+  pypi-publish:
+    name: Upload release to PyPI
+    if: github.event.inputs.publish_to_pypi
+    runs-on: ubuntu-24.04
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download the wheel and source archive from the draft release.
+        run: |
+          mkdir -p assets
+          gh release download --dir=assets --pattern='shoalsoft' ${{ github.event.inputs.release_tag }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        - name: Publish package distributions to TestPyPI
+          uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,6 +54,7 @@ jobs:
         with:
           packages-dir: assets/
           repository-url: https://test.pypi.org/legacy/
+          verbose: true
 
   pypi-publish:
     name: Upload release to PyPI
@@ -74,3 +75,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: assets/
+          verbose: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,14 +22,15 @@ jobs:
       - name: Validate the release.
         run: |
           gh release view "$RELEASE_TAG" --json=assets,isDraft > release-info.json
-          if [ "$(cat release-info.json | jq .isDraft)" != "false" ]; then
+          if [ "$(jq .isDraft release-info.json)" != "false" ]; then
             echo "ERROR: Release $RELEASE_TAG is still in draft mode." 1>&2
             exit 1
           fi
-          if [ "$(cat release-info.json | jq '[.assets[] | select(.name | startswith("shoalsoft_"))] | length')"" != "2" ]; then
+          if [ "$(jq '[.assets[] | select(.name | startswith("shoalsoft_"))] | length' release-info.json)" != "2" ]; then
             echo "ERROR: Release $RELEASE_TAG does not have contain all of the expected assets." 1>&2
             exit 1
           fi
+          echo "SUCCESS: Release $RELEASE_TAG appears to be ready for distribution."
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.inputs.release_tag }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -55,6 +55,7 @@ jobs:
           packages-dir: assets/
           repository-url: https://test.pypi.org/legacy/
           verbose: true
+          print-hash: true
 
   pypi-publish:
     name: Upload release to PyPI
@@ -76,3 +77,4 @@ jobs:
         with:
           packages-dir: assets/
           verbose: true
+          print-hash: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,12 +26,13 @@ jobs:
       - name: Download the wheel and source archive from the draft release.
         run: |
           mkdir -p assets
-          gh release download --dir=assets --pattern='shoalsoft' ${{ github.event.inputs.release_tag }}
+          gh release download --dir=assets --pattern='shoalsoft*' ${{ github.event.inputs.release_tag }}
         env:
           GH_TOKEN: ${{ github.token }}
         - name: Publish package distributions to TestPyPI
           uses: pypa/gh-action-pypi-publish@release/v1
           with:
+            packages-dir: assets/
             repository-url: https://test.pypi.org/legacy/
 
   pypi-publish:
@@ -45,8 +46,10 @@ jobs:
       - name: Download the wheel and source archive from the draft release.
         run: |
           mkdir -p assets
-          gh release download --dir=assets --pattern='shoalsoft' ${{ github.event.inputs.release_tag }}
+          gh release download --dir=assets --pattern='shoalsoft*' ${{ github.event.inputs.release_tag }}
         env:
           GH_TOKEN: ${{ github.token }}
         - name: Publish package distributions to TestPyPI
           uses: pypa/gh-action-pypi-publish@release/v1
+          with:
+            packages-dir: assets/


### PR DESCRIPTION
Add a workflow for [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) so publishing doesn't involve a manual step.