### PR TITLE
booleans are strings in GHA workflows

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,7 +40,7 @@ jobs:
 
   testpypi-publish:
     name: Upload release to TestPyPI
-    if: github.event.inputs.publish_to_testpypi
+    if: ${{ github.event.inputs.publish_to_testpypi == 'true' }}
     needs: validate-release
     runs-on: ubuntu-24.04
     environment: testpypi
@@ -65,7 +65,7 @@ jobs:
 
   pypi-publish:
     name: Upload release to PyPI
-    if: github.event.inputs.publish_to_pypi
+    if: ${{ github.event.inputs.publish_to_pypi == 'true' }}
     needs: validate-release
     runs-on: ubuntu-24.04
     environment: pypi


### PR DESCRIPTION
Both workflows were activating even when one of the inputs was false. Turns out the booleans ends up as strings?