### PR TITLE
[WIP] add honeycomb.io span export for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,10 +22,16 @@ jobs:
           # cache0 makes it easy to bust the cache if needed
           gha-cache-key: cache0-py3.11
           named-caches-hash: ${{ hashFiles('3rdparty/python/pants-2.27.lock') }}
+        env:
+          HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
       - name: Lint and typecheck the code
         run: "pants lint check ::"
+        env:
+          HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
       - name: Run tests
         run: "pants test ::"
+        env:
+          HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
       - name: Package plugin as PEX for various Pants versions.
         run: |
           pants package src/python/shoalsoft/pants_opentelemetry_plugin::
@@ -39,6 +45,8 @@ jobs:
               exit 1
             fi
           done
+        env:
+          HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
       - name: Upload pants.log
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/create-draft-release.yaml
+++ b/.github/workflows/create-draft-release.yaml
@@ -33,8 +33,12 @@ jobs:
           # cache0 makes it easy to bust the cache if needed
           gha-cache-key: cache0-py3.11
           named-caches-hash: ${{ hashFiles('3rdparty/python/pants-2.27.lock') }}
+        env:
+          HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
       - name: Run tests
         run: "pants test ::"
+        env:
+          HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
       - name: Package the plugin as a wheel
         id: package
         run: |
@@ -53,7 +57,8 @@ jobs:
           fi
           echo "wheel-local-path=$wheel_file" >> $GITHUB_OUTPUT
           echo "source-archive-file=$source_archive_file" >> $GITHUB_OUTPUT
-          
+        env:
+          HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
       - name: Attest provenance of the wheel and source archive.
         uses: actions/attest-build-provenance@v2
         with:

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -8,8 +8,8 @@ pantsd = false
 
 [shoalsoft-opentelemetry]
 enabled = true
-exporter = "grpc"
-exporter_endpoint = "https://api.honeycomb.io"
+exporter = "http"
+exporter_endpoint = "https://api.honeycomb.io:443"
 async_completion = false
 
 [shoalsoft-opentelemetry.exporter_headers]

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -1,0 +1,17 @@
+[GLOBAL]
+pythonpath.add = ["%(buildroot)s/src/python"]
+backend_packages.add = ["shoalsoft.pants_opentelemetry_plugin"]
+print_stacktrace = true
+level = "debug"
+log_show_rust_3rdparty = true
+pantsd = false
+
+[shoalsoft-opentelemetry]
+enabled = true
+exporter = "grpc"
+exporter_endpoint = "https://api.honeycomb.io"
+async_completion = false
+
+[shoalsoft-opentelemetry.exporter_headers]
+"x-honeycomb-team" = "%(env.HONEYCOMB_API_KEY)s"
+

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -9,7 +9,7 @@ pantsd = false
 [shoalsoft-opentelemetry]
 enabled = true
 exporter = "http"
-exporter_endpoint = "https://api.honeycomb.io:443"
+exporter_endpoint = "https://api.honeycomb.io:443/v1/traces"
 async_completion = false
 
 [shoalsoft-opentelemetry.exporter_headers]


### PR DESCRIPTION
Add CI-only configuration to export this plugin's CI work units to Honeycomb. This will help test the plugin in a more real world like scenario.