### PR TITLE
upgrade Pants versions used for testing

### DIFF
--- a/3rdparty/python/pants-2.25.lock
+++ b/3rdparty/python/pants-2.25.lock
@@ -16,8 +16,8 @@
 //     "opentelemetry-proto==1.34.1",
 //     "opentelemetry-sdk==1.34.1",
 //     "packaging",
-//     "pantsbuild.pants.testutil==2.25.2",
-//     "pantsbuild.pants==2.25.2",
+//     "pantsbuild.pants.testutil==2.25.3",
+//     "pantsbuild.pants==2.25.3",
 //     "pytest",
 //     "toml==0.10.2"
 //   ],
@@ -850,23 +850,23 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4f1cad2b2b63fc6560c5e57d272bdf685a5cca733898982f36da434f36582e3d",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.25.2/pantsbuild.pants-2.25.2-cp311-cp311-manylinux2014_x86_64.whl"
+              "hash": "97ee247b300f33a2fcec789c4eb4dd65209f6545da5ea54e94c1bdfb57a9618d",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.25.3/pantsbuild.pants-2.25.3-cp311-cp311-manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e38578636c3f33c21f9e7cf325bdd83a031ca6ff64acea1892607b2440467a1a",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.25.2/pantsbuild.pants-2.25.2-cp311-cp311-macosx_13_0_x86_64.whl"
+              "hash": "7a56a7f48665e476bb95e7f34ab83446f7403ea6e8929e63aac6f8a04c5f8657",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.25.3/pantsbuild.pants-2.25.3-cp311-cp311-macosx_13_0_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b54f0de0051e891ac77f649e2189015eb97af220a04e7e84d6734b123e101f09",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.25.2/pantsbuild.pants-2.25.2-cp311-cp311-macosx_14_0_arm64.whl"
+              "hash": "283ff294f38c6eadfe2437873eab85fabbc4ec709a083d5d0173ad1adbd5912d",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.25.3/pantsbuild.pants-2.25.3-cp311-cp311-macosx_14_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "75997e4f2943867b9863daf5cfa5239d02e749ce29eb2460f14a0392eee633b1",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.25.2/pantsbuild.pants-2.25.2-cp311-cp311-manylinux2014_aarch64.whl"
+              "hash": "2879a02faa730ef11afa22c8369f477e6475194ddfe154cd5c106a26f73add0f",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.25.3/pantsbuild.pants-2.25.3-cp311-cp311-manylinux2014_aarch64.whl"
             }
           ],
           "project_name": "pantsbuild-pants",
@@ -890,25 +890,25 @@
             "typing-extensions~=4.12"
           ],
           "requires_python": "==3.11.*",
-          "version": "2.25.2"
+          "version": "2.25.3"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e4e41ed6a2a52457d74ebd0d3079a14c97039a44cf7b72059da975395a728d5a",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.25.2/pantsbuild.pants.testutil-2.25.2-py3-none-any.whl"
+              "hash": "9057586527bea87fe6c13c0385fa53c641fdc7f36c93d7d6b956c0510acd2344",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.25.3/pantsbuild.pants.testutil-2.25.3-py3-none-any.whl"
             }
           ],
           "project_name": "pantsbuild-pants-testutil",
           "requires_dists": [
-            "pantsbuild.pants==2.25.2",
+            "pantsbuild.pants==2.25.3",
             "pytest<7.1.0,>=6.2.4",
             "toml==0.10.2",
             "types-toml==0.10.8"
           ],
           "requires_python": "==3.11.*",
-          "version": "2.25.2"
+          "version": "2.25.3"
         },
         {
           "artifacts": [
@@ -1477,19 +1477,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af",
-              "url": "https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl"
+              "hash": "d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76",
+              "url": "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4",
-              "url": "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz"
+              "hash": "38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36",
+              "url": "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.9",
-          "version": "4.14.0"
+          "version": "4.14.1"
         },
         {
           "artifacts": [
@@ -1548,13 +1548,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813",
-              "url": "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl"
+              "hash": "e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc",
+              "url": "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466",
-              "url": "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz"
+              "hash": "3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760",
+              "url": "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz"
             }
           ],
           "project_name": "urllib3",
@@ -1566,7 +1566,7 @@
             "zstandard>=0.18.0; extra == \"zstd\""
           ],
           "requires_python": ">=3.9",
-          "version": "2.4.0"
+          "version": "2.5.0"
         },
         {
           "artifacts": [
@@ -1624,8 +1624,8 @@
     "opentelemetry-proto==1.34.1",
     "opentelemetry-sdk==1.34.1",
     "packaging",
-    "pantsbuild.pants.testutil==2.25.2",
-    "pantsbuild.pants==2.25.2",
+    "pantsbuild.pants.testutil==2.25.3",
+    "pantsbuild.pants==2.25.3",
     "pytest",
     "toml==0.10.2"
   ],

--- a/3rdparty/python/pants-2.25.txt
+++ b/3rdparty/python/pants-2.25.txt
@@ -1,6 +1,6 @@
 # Pants dependencies
-pantsbuild.pants==2.25.2
-pantsbuild.pants.testutil==2.25.2
+pantsbuild.pants==2.25.3
+pantsbuild.pants.testutil==2.25.3
 
 # OpenTelemetry dependencies
 opentelemetry-api==1.34.1

--- a/3rdparty/python/pants-2.26.lock
+++ b/3rdparty/python/pants-2.26.lock
@@ -16,8 +16,8 @@
 //     "opentelemetry-proto==1.34.1",
 //     "opentelemetry-sdk==1.34.1",
 //     "packaging",
-//     "pantsbuild.pants.testutil==2.26.1",
-//     "pantsbuild.pants==2.26.1",
+//     "pantsbuild.pants.testutil==2.26.2",
+//     "pantsbuild.pants==2.26.2",
 //     "pytest",
 //     "toml==0.10.2"
 //   ],
@@ -848,23 +848,23 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f3fe52b308b670c3981482aa5c605d045d62e330fbffa9aec39ce46e46b70696",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.26.1/pantsbuild.pants-2.26.1-cp311-cp311-manylinux2014_x86_64.whl"
+              "hash": "abcb0ab54120ad14d41effd86b81c6130a5dd34273fcdbd7b89dcb9dffc873bf",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.26.2/pantsbuild.pants-2.26.2-cp311-cp311-manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "16df6e7fae7ec1917025cc7e5ffbf8612bb65a25689156abce5d187f6d70b5f3",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.26.1/pantsbuild.pants-2.26.1-cp311-cp311-macosx_13_0_x86_64.whl"
+              "hash": "ae20d7f575482770a19b7dfd44bcd507b04bfccc2c0c894db26fbd2044174ab1",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.26.2/pantsbuild.pants-2.26.2-cp311-cp311-macosx_13_0_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1f91f67f3199b84be98d239f8824cdad25bd8e0dcbe8a12eb23c75b0fd2f6b7d",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.26.1/pantsbuild.pants-2.26.1-cp311-cp311-macosx_14_0_arm64.whl"
+              "hash": "2f6a7857f32462081b9b028144de44a3381b1ca58663a3b9f1f5531c37c1e438",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.26.2/pantsbuild.pants-2.26.2-cp311-cp311-macosx_14_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "80893c2a4cc46c8ebf9d87ec3670c0bb268982a49607a164f25c4aac6142e9ed",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.26.1/pantsbuild.pants-2.26.1-cp311-cp311-manylinux2014_aarch64.whl"
+              "hash": "8d7867a836b72e645144ab3b3b3c653e007f02219aa4795135a854382a1c6190",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.26.2/pantsbuild.pants-2.26.2-cp311-cp311-manylinux2014_aarch64.whl"
             }
           ],
           "project_name": "pantsbuild-pants",
@@ -888,25 +888,25 @@
             "typing-extensions~=4.12"
           ],
           "requires_python": "==3.11.*",
-          "version": "2.26.1"
+          "version": "2.26.2"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "93e4d48f644af65a411e586df68a558882efb0131852178bde9ee27c0b009c27",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.26.1/pantsbuild.pants.testutil-2.26.1-py3-none-any.whl"
+              "hash": "207cc528faecb46a7dd457aadb6cddb3f76b7e8825aacd2ddde6948234f3c0c2",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.26.2/pantsbuild.pants.testutil-2.26.2-py3-none-any.whl"
             }
           ],
           "project_name": "pantsbuild-pants-testutil",
           "requires_dists": [
-            "pantsbuild.pants==2.26.1",
+            "pantsbuild.pants==2.26.2",
             "pytest<7.1.0,>=6.2.4",
             "toml==0.10.2",
             "types-toml==0.10.8"
           ],
           "requires_python": "==3.11.*",
-          "version": "2.26.1"
+          "version": "2.26.2"
         },
         {
           "artifacts": [
@@ -1454,19 +1454,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af",
-              "url": "https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl"
+              "hash": "d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76",
+              "url": "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4",
-              "url": "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz"
+              "hash": "38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36",
+              "url": "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.9",
-          "version": "4.14.0"
+          "version": "4.14.1"
         },
         {
           "artifacts": [
@@ -1525,13 +1525,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813",
-              "url": "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl"
+              "hash": "e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc",
+              "url": "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466",
-              "url": "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz"
+              "hash": "3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760",
+              "url": "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz"
             }
           ],
           "project_name": "urllib3",
@@ -1543,7 +1543,7 @@
             "zstandard>=0.18.0; extra == \"zstd\""
           ],
           "requires_python": ">=3.9",
-          "version": "2.4.0"
+          "version": "2.5.0"
         },
         {
           "artifacts": [
@@ -1601,8 +1601,8 @@
     "opentelemetry-proto==1.34.1",
     "opentelemetry-sdk==1.34.1",
     "packaging",
-    "pantsbuild.pants.testutil==2.26.1",
-    "pantsbuild.pants==2.26.1",
+    "pantsbuild.pants.testutil==2.26.2",
+    "pantsbuild.pants==2.26.2",
     "pytest",
     "toml==0.10.2"
   ],

--- a/3rdparty/python/pants-2.26.txt
+++ b/3rdparty/python/pants-2.26.txt
@@ -1,6 +1,6 @@
 # Pants dependencies
-pantsbuild.pants==2.26.1
-pantsbuild.pants.testutil==2.26.1
+pantsbuild.pants==2.26.2
+pantsbuild.pants.testutil==2.26.2
 
 # OpenTelemetry dependencies
 opentelemetry-api==1.34.1

--- a/3rdparty/python/pants-2.27.lock
+++ b/3rdparty/python/pants-2.27.lock
@@ -16,8 +16,8 @@
 //     "opentelemetry-proto==1.34.1",
 //     "opentelemetry-sdk==1.34.1",
 //     "packaging",
-//     "pantsbuild.pants.testutil==2.27.0rc1",
-//     "pantsbuild.pants==2.27.0rc1",
+//     "pantsbuild.pants.testutil==2.27.0",
+//     "pantsbuild.pants==2.27.0",
 //     "pytest",
 //     "toml==0.10.2"
 //   ],
@@ -888,23 +888,23 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a4f32cd1cf1feaa139230f9481b7ed8b65b86c64b50cef2520f38a39e7dfff8b",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.27.0rc1/pantsbuild.pants-2.27.0rc1-cp311-cp311-manylinux2014_x86_64.whl"
+              "hash": "b8d9e3f6419d4b2377be6dd0ef5471b20014487822f4f81f9e692ca0e9446cfc",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.27.0/pantsbuild.pants-2.27.0-cp311-cp311-manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4abbf3edda81566139f029ed5e1a3d5950f025be6673e40996b4dadb05afea76",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.27.0rc1/pantsbuild.pants-2.27.0rc1-cp311-cp311-macosx_13_0_x86_64.whl"
+              "hash": "a69d5353543a7adedc9cb9dbcb225af82f91133e219e95f5bff5a308398dc786",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.27.0/pantsbuild.pants-2.27.0-cp311-cp311-macosx_13_0_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "56c142601b18cc1a4e95e26433942b12a83aee4004be6067644a3c82b972c3e1",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.27.0rc1/pantsbuild.pants-2.27.0rc1-cp311-cp311-macosx_14_0_arm64.whl"
+              "hash": "af31705c5e8001a02679551a2d30e0b28f301e05e67b0b7037d22c244b537a1e",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.27.0/pantsbuild.pants-2.27.0-cp311-cp311-macosx_14_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1de760689460426087b689bab43206a51376d17c8143a043896df7ecb84e77f2",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.27.0rc1/pantsbuild.pants-2.27.0rc1-cp311-cp311-manylinux2014_aarch64.whl"
+              "hash": "8c68c2720cd9b3c8a9de97f604dbe69e5e7653577c09a61feb1ed7d3711a811e",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.27.0/pantsbuild.pants-2.27.0-cp311-cp311-manylinux2014_aarch64.whl"
             }
           ],
           "project_name": "pantsbuild-pants",
@@ -929,25 +929,25 @@
             "typing-extensions~=4.12"
           ],
           "requires_python": "==3.11.*",
-          "version": "2.27.0rc1"
+          "version": "2.27.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e2fef6db0b94090dd6b665ae73bb1f1ada787588badbd3e88d6afb1010f5b0e3",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.27.0rc1/pantsbuild.pants.testutil-2.27.0rc1-py3-none-any.whl"
+              "hash": "78bf213db217433574a0c3cb8e17c6a26cc19a338511c800b41d4a97c172d76f",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.27.0/pantsbuild.pants.testutil-2.27.0-py3-none-any.whl"
             }
           ],
           "project_name": "pantsbuild-pants-testutil",
           "requires_dists": [
-            "pantsbuild.pants==2.27.0rc1",
+            "pantsbuild.pants==2.27.0",
             "pytest<7.1.0,>=6.2.4",
             "toml==0.10.2",
             "types-toml==0.10.8"
           ],
           "requires_python": "==3.11.*",
-          "version": "2.27.0rc1"
+          "version": "2.27.0"
         },
         {
           "artifacts": [
@@ -1515,19 +1515,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af",
-              "url": "https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl"
+              "hash": "d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76",
+              "url": "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4",
-              "url": "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz"
+              "hash": "38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36",
+              "url": "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.9",
-          "version": "4.14.0"
+          "version": "4.14.1"
         },
         {
           "artifacts": [
@@ -1586,13 +1586,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813",
-              "url": "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl"
+              "hash": "e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc",
+              "url": "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466",
-              "url": "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz"
+              "hash": "3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760",
+              "url": "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz"
             }
           ],
           "project_name": "urllib3",
@@ -1604,7 +1604,7 @@
             "zstandard>=0.18.0; extra == \"zstd\""
           ],
           "requires_python": ">=3.9",
-          "version": "2.4.0"
+          "version": "2.5.0"
         },
         {
           "artifacts": [
@@ -1662,8 +1662,8 @@
     "opentelemetry-proto==1.34.1",
     "opentelemetry-sdk==1.34.1",
     "packaging",
-    "pantsbuild.pants.testutil==2.27.0rc1",
-    "pantsbuild.pants==2.27.0rc1",
+    "pantsbuild.pants.testutil==2.27.0",
+    "pantsbuild.pants==2.27.0",
     "pytest",
     "toml==0.10.2"
   ],

--- a/3rdparty/python/pants-2.27.txt
+++ b/3rdparty/python/pants-2.27.txt
@@ -1,6 +1,6 @@
 # Pants dependencies
-pantsbuild.pants==2.27.0rc1
-pantsbuild.pants.testutil==2.27.0rc1
+pantsbuild.pants==2.27.0
+pantsbuild.pants.testutil==2.27.0
 
 # OpenTelemetry dependencies
 opentelemetry-api==1.34.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ This is a Pants plugin that enables OpenTelemetry tracing for Pantsbuild workflo
 
 ## Development Commands
 
+**Important**: When running `pants` commands, use the globally-installed Pants launcher at `/usr/local/bin/pants` instead of any virtual environment executable.
+
 - **Format and lint**: `pants fmt lint check ::`
 - **Run tests**: `pants test ::`  
 - **Run integration tests**: `pants test src/python/shoalsoft/pants_opentelemetry_plugin:integration_tests`
@@ -17,6 +19,15 @@ This is a Pants plugin that enables OpenTelemetry tracing for Pantsbuild workflo
 ## Multi-Version Support
 
 The plugin supports multiple Pants versions (2.25, 2.26, 2.27) using Pants' parametrize feature. Each version has its own lockfile in `3rdparty/python/pants-*.lock` and separate build targets. These lockfiles are mainly for integration testing. The distribution wheel is agnostic to Pants version.
+
+### Updating Pants Versions
+
+To update Pants versions or regenerate lockfiles:
+
+1. Update the version constraints in `3rdparty/python/pants-*.txt` files
+2. Regenerate the corresponding lockfiles: `pants generate-lockfiles --resolve=pants-X.XX`
+3. For all resolves: `pants generate-lockfiles`
+4. Update the integration test to include the new version in the parametrize decorator
 
 ## Architecture
 

--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.27.0rc1"
+pants_version = "2.27.0"
 backend_packages.add = [
   "pants.backend.build_files.fmt.black",
   "pants.backend.plugin_development",

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry_integration_test.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry_integration_test.py
@@ -312,7 +312,7 @@ def do_test_of_json_file_exporter(
         )
 
 
-@pytest.mark.parametrize("pants_version_str", ["2.27.0rc1", "2.26.1", "2.25.2"])
+@pytest.mark.parametrize("pants_version_str", ["2.27.0", "2.26.2", "2.25.3"])
 def test_opentelemetry_integration(subtests, pants_version_str: str) -> None:
     pants_version = Version(pants_version_str)
     pants_major_minor = f"{pants_version.major}.{pants_version.minor}"


### PR DESCRIPTION
Upgrade Pants versions used for testing (and for Pants runs) as follows:

- 2.27 -> 2.27.0
- 2.26 -> 2.26.2
- 2.25 -> 2.25.3