### PR TITLE
add `--shoalsoft-opentelemetry-async-completion` option

### DIFF
--- a/src/python/shoalsoft/pants_opentelemetry_plugin/register.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/register.py
@@ -69,7 +69,11 @@ async def telemetry_workunits_callback_factory_request(
     finish_timeout = datetime.timedelta(seconds=telemetry.finish_timeout)
     return WorkunitsCallbackFactory(
         lambda: (
-            TelemetryWorkunitsCallback(processor=processor, finish_timeout=finish_timeout)
+            TelemetryWorkunitsCallback(
+                processor=processor,
+                finish_timeout=finish_timeout,
+                async_completion=telemetry.async_completion,
+            )
             if processor is not None
             else None
         )

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/subsystem.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/subsystem.py
@@ -81,6 +81,18 @@ class TelemetrySubsystem(Subsystem):
         ),
     )
 
+    async_completion = BoolOption(
+        default=True,
+        help=softwrap(
+            """
+            If `True`, allows the plugin to finish asynchronously when Pants is shutting down. This can result in
+            faster Pants exit times but may lead to some spans not being exported if the export process is slow.
+            If `False`, forces synchronous completion, ensuring all spans are exported before Pants exits but
+            potentially slowing down the shutdown process.
+            """
+        ),
+    )
+
     json_file = StrOption(
         default="dist/otel-json-trace.jsonl",
         help=softwrap(

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/workunit_handler.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/workunit_handler.py
@@ -44,13 +44,20 @@ class _TelemetryContext(ProcessorContext):
 
 
 class TelemetryWorkunitsCallback(WorkunitsCallback):
-    def __init__(self, processor: Processor, *, finish_timeout: datetime.timedelta) -> None:
+    def __init__(
+        self,
+        processor: Processor,
+        *,
+        finish_timeout: datetime.timedelta,
+        async_completion: bool,
+    ) -> None:
         self.processor: Processor = processor
         self.finish_timeout = finish_timeout
+        self.async_completion = async_completion
 
     @property
     def can_finish_async(self) -> bool:
-        return True
+        return self.async_completion
 
     def _convert_time(self, seconds: int, nanoseconds: int) -> datetime.datetime:
         t = datetime.datetime(year=1970, month=1, day=1, tzinfo=datetime.timezone.utc)


### PR DESCRIPTION
Add a new `--shoalsoft-opentelemetry-async-completion` option to control async completion of work unit processing. By default, the option is enabled and Pants will not wait for the work unit handler to signal completion. This may result in loss of work units though if the handler is not able to transmit them in time. The option gives the user the choice.