### PR TITLE
add subprocess processor to offload gRPC-related work

### DIFF
--- a/3rdparty/python/BUILD
+++ b/3rdparty/python/BUILD
@@ -7,6 +7,9 @@ python_requirements(
         "pantsbuild.pants": ["pants"],
         "pantsbuild.pants.testutil": ["pants.testutil"],
     },
+    type_stubs_module_mapping={
+        "types-grpcio": ["grpc"],
+    },
 )
 
 python_requirements(
@@ -18,6 +21,9 @@ python_requirements(
         "pantsbuild.pants": ["pants"],
         "pantsbuild.pants.testutil": ["pants.testutil"],
     },
+    type_stubs_module_mapping={
+        "types-grpcio": ["grpc"],
+    },
 )
 
 python_requirements(
@@ -28,6 +34,9 @@ python_requirements(
         "opentelemetry-proto": ["opentelemetry.proto"],
         "pantsbuild.pants": ["pants"],
         "pantsbuild.pants.testutil": ["pants.testutil"],
+    },
+    type_stubs_module_mapping={
+        "types-grpcio": ["grpc"],
     },
 )
 

--- a/3rdparty/python/mypy.lock
+++ b/3rdparty/python/mypy.lock
@@ -122,19 +122,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af",
-              "url": "https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl"
+              "hash": "d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76",
+              "url": "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4",
-              "url": "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz"
+              "hash": "38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36",
+              "url": "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.9",
-          "version": "4.14.0"
+          "version": "4.14.1"
         }
       ],
       "platform_tag": null

--- a/3rdparty/python/pants-2.25.lock
+++ b/3rdparty/python/pants-2.25.lock
@@ -9,7 +9,7 @@
 //     "CPython==3.11.*"
 //   ],
 //   "generated_with_requirements": [
-//     "grpcio==1.70.0",
+//     "grpcio==1.73.1",
 //     "httpx==0.28.1",
 //     "opentelemetry-api==1.34.1",
 //     "opentelemetry-exporter-otlp==1.34.1",
@@ -19,7 +19,8 @@
 //     "pantsbuild.pants.testutil==2.25.3",
 //     "pantsbuild.pants==2.25.3",
 //     "pytest",
-//     "toml==0.10.2"
+//     "toml==0.10.2",
+//     "types-grpcio==1.0.0.20250703"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -158,19 +159,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
-              "url": "https://files.pythonhosted.org/packages/84/ae/320161bd181fc06471eed047ecce67b693fd7515b16d495d8932db763426/certifi-2025.6.15-py3-none-any.whl"
+              "hash": "d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39",
+              "url": "https://files.pythonhosted.org/packages/66/f3/80a3f974c8b535d394ff960a11ac20368e06b736da395b551a49ce950cce/certifi-2025.7.9-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b",
-              "url": "https://files.pythonhosted.org/packages/73/f7/f14b46d4bcd21092d7d3ccef689615220d8a08fb25e564b65d20738e672e/certifi-2025.6.15.tar.gz"
+              "hash": "c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079",
+              "url": "https://files.pythonhosted.org/packages/de/8a/c729b6b60c66a38f590c4e774decc4b2ec7b0576be8f1aa984a53ffa812a/certifi-2025.7.9.tar.gz"
             }
           ],
           "project_name": "certifi",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "2025.6.15"
+          "version": "2025.7.9"
         },
         {
           "artifacts": [
@@ -309,51 +310,56 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d63764963412e22f0491d0d32833d71087288f4e24cbcddbae82476bfa1d81fd",
-              "url": "https://files.pythonhosted.org/packages/4c/c4/684d877517e5bfd6232d79107e5a1151b835e9f99051faef51fed3359ec4/grpcio-1.70.0-cp311-cp311-musllinux_1_1_x86_64.whl"
+              "hash": "610e19b04f452ba6f402ac9aa94eb3d21fbc94553368008af634812c4a85a99e",
+              "url": "https://files.pythonhosted.org/packages/42/72/a13ff7ba6c68ccffa35dacdc06373a76c0008fd75777cba84d7491956620/grpcio-1.73.1-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "27cc75e22c5dba1fbaf5a66c778e36ca9b8ce850bf58a9db887754593080d839",
-              "url": "https://files.pythonhosted.org/packages/05/33/dbf035bc6d167068b4a9f2929dfe0b03fb763f0f861ecb3bb1709a14cb65/grpcio-1.70.0-cp311-cp311-musllinux_1_1_i686.whl"
+              "hash": "bc5eccfd9577a5dc7d5612b2ba90cca4ad14c6d949216c68585fdec9848befb1",
+              "url": "https://files.pythonhosted.org/packages/0e/64/12d6dc446021684ee1428ea56a3f3712048a18beeadbdefa06e6f8814a6e/grpcio-1.73.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "17325b0be0c068f35770f944124e8839ea3185d6d54862800fc28cc2ffad205a",
-              "url": "https://files.pythonhosted.org/packages/65/c4/1f67d23d6bcadd2fd61fb460e5969c52b3390b4a4e254b5e04a6d1009e5e/grpcio-1.70.0-cp311-cp311-linux_armv7l.whl"
+              "hash": "105492124828911f85127e4825d1c1234b032cb9d238567876b5515d01151379",
+              "url": "https://files.pythonhosted.org/packages/38/64/02c83b5076510784d1305025e93e0d78f53bb6a0213c8c84cfe8a00c5c48/grpcio-1.73.1-cp311-cp311-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8d1584a68d5922330025881e63a6c1b54cc8117291d382e4fa69339b6d914c56",
-              "url": "https://files.pythonhosted.org/packages/69/e1/4b21b5017c33f3600dcc32b802bb48fe44a4d36d6c066f52650c7c2690fa/grpcio-1.70.0.tar.gz"
+              "hash": "b3215f69a0670a8cfa2ab53236d9e8026bfb7ead5d4baabe7d7dc11d30fda967",
+              "url": "https://files.pythonhosted.org/packages/5d/47/36deacd3c967b74e0265f4c608983e897d8bb3254b920f8eafdf60e4ad7e/grpcio-1.73.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5ea67c72101d687d44d9c56068328da39c9ccba634cabb336075fae2eab0d04b",
-              "url": "https://files.pythonhosted.org/packages/7e/32/8538bb2ace5cd72da7126d1c9804bf80b4fe3be70e53e2d55675c24961a8/grpcio-1.70.0-cp311-cp311-manylinux_2_17_aarch64.whl"
+              "hash": "dc7d7fd520614fce2e6455ba89791458020a39716951c7c07694f9dbae28e9c0",
+              "url": "https://files.pythonhosted.org/packages/72/4b/6bae2d88a006000f1152d2c9c10ffd41d0131ca1198e0b661101c2e30ab9/grpcio-1.73.1-cp311-cp311-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e7831a0fc1beeeb7759f737f5acd9fdcda520e955049512d68fda03d91186eea",
-              "url": "https://files.pythonhosted.org/packages/9f/e5/5316b239380b8b2ad30373eb5bb25d9fd36c0375e94a98a0a60ea357d254/grpcio-1.70.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "7fce2cd1c0c1116cf3850564ebfc3264fba75d3c74a7414373f1238ea365ef87",
+              "url": "https://files.pythonhosted.org/packages/79/e8/b43b851537da2e2f03fa8be1aef207e5cbfb1a2e014fbb6b40d24c177cd3/grpcio-1.73.1.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "cb5277db254ab7586769e490b7b22f4ddab3876c490da0a1a9d7c695ccf0bf77",
-              "url": "https://files.pythonhosted.org/packages/ce/5c/a45f85f2a0dfe4a6429dee98717e0e8bd7bd3f604315493c39d9679ca065/grpcio-1.70.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "5b9b1805a7d61c9e90541cbe8dfe0a593dfc8c5c3a43fe623701b6a01b01d710",
+              "url": "https://files.pythonhosted.org/packages/8f/d3/33d738a06f6dbd4943f4d377468f8299941a7c8c6ac8a385e4cef4dd3c93/grpcio-1.73.1-cp311-cp311-manylinux_2_17_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dbe41ad140df911e796d4463168e33ef80a24f5d21ef4d1e310553fcd2c4a386",
-              "url": "https://files.pythonhosted.org/packages/e4/bd/cc36811c582d663a740fb45edf9f99ddbd99a10b6ba38267dc925e1e193a/grpcio-1.70.0-cp311-cp311-macosx_10_14_universal2.whl"
+              "hash": "d74c3f4f37b79e746271aa6cdb3a1d7e4432aea38735542b23adcabaaee0c097",
+              "url": "https://files.pythonhosted.org/packages/b0/cc/9c51109c71d068e4d474becf5f5d43c9d63038cec1b74112978000fa72f4/grpcio-1.73.1-cp311-cp311-macosx_11_0_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ba2cea9f7ae4bc21f42015f0ec98f69ae4179848ad744b210e7685112fa507a1",
+              "url": "https://files.pythonhosted.org/packages/e4/41/921565815e871d84043e73e2c0e748f0318dab6fa9be872cd042778f14a9/grpcio-1.73.1-cp311-cp311-linux_armv7l.whl"
             }
           ],
           "project_name": "grpcio",
           "requires_dists": [
-            "grpcio-tools>=1.70.0; extra == \"protobuf\""
+            "grpcio-tools>=1.73.1; extra == \"protobuf\""
           ],
-          "requires_python": ">=3.8",
-          "version": "1.70.0"
+          "requires_python": ">=3.9",
+          "version": "1.73.1"
         },
         {
           "artifacts": [
@@ -1423,6 +1429,24 @@
           "artifacts": [
             {
               "algorithm": "sha256",
+              "hash": "78d1bfc33b58a56697ef99e666e34be4c6887631341c75fdd28d58587aef5d9f",
+              "url": "https://files.pythonhosted.org/packages/b9/e2/9c682ba59a7f9cf477bc7954c25ce1c20f881693651f354d15df577996c0/types_grpcio-1.0.0.20250703-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "baf100184e5353cb60f045fb4fd47f37a360bedf0f19581535e4c3a3a1f7912b",
+              "url": "https://files.pythonhosted.org/packages/59/17/c80b7231e337993b808aef32bcc556aad60810ca51eeb7acd1204eefe518/types_grpcio-1.0.0.20250703.tar.gz"
+            }
+          ],
+          "project_name": "types-grpcio",
+          "requires_dists": [],
+          "requires_python": ">=3.9",
+          "version": "1.0.0.20250703"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
               "hash": "8b50294b55a9db89498cdc5a65b1b4545112b6cd1cf4465bd693d828b0282a17",
               "url": "https://files.pythonhosted.org/packages/47/be/b5e816c7299fa0a9f5b96ab7ae13920d51dfc90948b902de37935e0efa79/types_PyYAML-6.0.3-py3-none-any.whl"
             },
@@ -1617,7 +1641,7 @@
   "pip_version": "25.0",
   "prefer_older_binary": false,
   "requirements": [
-    "grpcio==1.70.0",
+    "grpcio==1.73.1",
     "httpx==0.28.1",
     "opentelemetry-api==1.34.1",
     "opentelemetry-exporter-otlp==1.34.1",
@@ -1627,7 +1651,8 @@
     "pantsbuild.pants.testutil==2.25.3",
     "pantsbuild.pants==2.25.3",
     "pytest",
-    "toml==0.10.2"
+    "toml==0.10.2",
+    "types-grpcio==1.0.0.20250703"
   ],
   "requires_python": [
     "==3.11.*"

--- a/3rdparty/python/pants-2.25.txt
+++ b/3rdparty/python/pants-2.25.txt
@@ -12,5 +12,6 @@ pytest
 toml==0.10.2
 httpx==0.28.1
 opentelemetry-proto==1.34.1
-grpcio==1.70.0
+grpcio==1.73.1
+types-grpcio==1.0.0.20250703
 packaging  # match version in Pants repository

--- a/3rdparty/python/pants-2.26.lock
+++ b/3rdparty/python/pants-2.26.lock
@@ -9,7 +9,7 @@
 //     "CPython==3.11.*"
 //   ],
 //   "generated_with_requirements": [
-//     "grpcio==1.70.0",
+//     "grpcio==1.73.1",
 //     "httpx==0.28.1",
 //     "opentelemetry-api==1.34.1",
 //     "opentelemetry-exporter-otlp==1.34.1",
@@ -19,7 +19,8 @@
 //     "pantsbuild.pants.testutil==2.26.2",
 //     "pantsbuild.pants==2.26.2",
 //     "pytest",
-//     "toml==0.10.2"
+//     "toml==0.10.2",
+//     "types-grpcio==1.0.0.20250703"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -158,19 +159,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
-              "url": "https://files.pythonhosted.org/packages/84/ae/320161bd181fc06471eed047ecce67b693fd7515b16d495d8932db763426/certifi-2025.6.15-py3-none-any.whl"
+              "hash": "d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39",
+              "url": "https://files.pythonhosted.org/packages/66/f3/80a3f974c8b535d394ff960a11ac20368e06b736da395b551a49ce950cce/certifi-2025.7.9-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b",
-              "url": "https://files.pythonhosted.org/packages/73/f7/f14b46d4bcd21092d7d3ccef689615220d8a08fb25e564b65d20738e672e/certifi-2025.6.15.tar.gz"
+              "hash": "c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079",
+              "url": "https://files.pythonhosted.org/packages/de/8a/c729b6b60c66a38f590c4e774decc4b2ec7b0576be8f1aa984a53ffa812a/certifi-2025.7.9.tar.gz"
             }
           ],
           "project_name": "certifi",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "2025.6.15"
+          "version": "2025.7.9"
         },
         {
           "artifacts": [
@@ -309,51 +310,56 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d63764963412e22f0491d0d32833d71087288f4e24cbcddbae82476bfa1d81fd",
-              "url": "https://files.pythonhosted.org/packages/4c/c4/684d877517e5bfd6232d79107e5a1151b835e9f99051faef51fed3359ec4/grpcio-1.70.0-cp311-cp311-musllinux_1_1_x86_64.whl"
+              "hash": "610e19b04f452ba6f402ac9aa94eb3d21fbc94553368008af634812c4a85a99e",
+              "url": "https://files.pythonhosted.org/packages/42/72/a13ff7ba6c68ccffa35dacdc06373a76c0008fd75777cba84d7491956620/grpcio-1.73.1-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "27cc75e22c5dba1fbaf5a66c778e36ca9b8ce850bf58a9db887754593080d839",
-              "url": "https://files.pythonhosted.org/packages/05/33/dbf035bc6d167068b4a9f2929dfe0b03fb763f0f861ecb3bb1709a14cb65/grpcio-1.70.0-cp311-cp311-musllinux_1_1_i686.whl"
+              "hash": "bc5eccfd9577a5dc7d5612b2ba90cca4ad14c6d949216c68585fdec9848befb1",
+              "url": "https://files.pythonhosted.org/packages/0e/64/12d6dc446021684ee1428ea56a3f3712048a18beeadbdefa06e6f8814a6e/grpcio-1.73.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "17325b0be0c068f35770f944124e8839ea3185d6d54862800fc28cc2ffad205a",
-              "url": "https://files.pythonhosted.org/packages/65/c4/1f67d23d6bcadd2fd61fb460e5969c52b3390b4a4e254b5e04a6d1009e5e/grpcio-1.70.0-cp311-cp311-linux_armv7l.whl"
+              "hash": "105492124828911f85127e4825d1c1234b032cb9d238567876b5515d01151379",
+              "url": "https://files.pythonhosted.org/packages/38/64/02c83b5076510784d1305025e93e0d78f53bb6a0213c8c84cfe8a00c5c48/grpcio-1.73.1-cp311-cp311-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8d1584a68d5922330025881e63a6c1b54cc8117291d382e4fa69339b6d914c56",
-              "url": "https://files.pythonhosted.org/packages/69/e1/4b21b5017c33f3600dcc32b802bb48fe44a4d36d6c066f52650c7c2690fa/grpcio-1.70.0.tar.gz"
+              "hash": "b3215f69a0670a8cfa2ab53236d9e8026bfb7ead5d4baabe7d7dc11d30fda967",
+              "url": "https://files.pythonhosted.org/packages/5d/47/36deacd3c967b74e0265f4c608983e897d8bb3254b920f8eafdf60e4ad7e/grpcio-1.73.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5ea67c72101d687d44d9c56068328da39c9ccba634cabb336075fae2eab0d04b",
-              "url": "https://files.pythonhosted.org/packages/7e/32/8538bb2ace5cd72da7126d1c9804bf80b4fe3be70e53e2d55675c24961a8/grpcio-1.70.0-cp311-cp311-manylinux_2_17_aarch64.whl"
+              "hash": "dc7d7fd520614fce2e6455ba89791458020a39716951c7c07694f9dbae28e9c0",
+              "url": "https://files.pythonhosted.org/packages/72/4b/6bae2d88a006000f1152d2c9c10ffd41d0131ca1198e0b661101c2e30ab9/grpcio-1.73.1-cp311-cp311-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e7831a0fc1beeeb7759f737f5acd9fdcda520e955049512d68fda03d91186eea",
-              "url": "https://files.pythonhosted.org/packages/9f/e5/5316b239380b8b2ad30373eb5bb25d9fd36c0375e94a98a0a60ea357d254/grpcio-1.70.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "7fce2cd1c0c1116cf3850564ebfc3264fba75d3c74a7414373f1238ea365ef87",
+              "url": "https://files.pythonhosted.org/packages/79/e8/b43b851537da2e2f03fa8be1aef207e5cbfb1a2e014fbb6b40d24c177cd3/grpcio-1.73.1.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "cb5277db254ab7586769e490b7b22f4ddab3876c490da0a1a9d7c695ccf0bf77",
-              "url": "https://files.pythonhosted.org/packages/ce/5c/a45f85f2a0dfe4a6429dee98717e0e8bd7bd3f604315493c39d9679ca065/grpcio-1.70.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "5b9b1805a7d61c9e90541cbe8dfe0a593dfc8c5c3a43fe623701b6a01b01d710",
+              "url": "https://files.pythonhosted.org/packages/8f/d3/33d738a06f6dbd4943f4d377468f8299941a7c8c6ac8a385e4cef4dd3c93/grpcio-1.73.1-cp311-cp311-manylinux_2_17_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dbe41ad140df911e796d4463168e33ef80a24f5d21ef4d1e310553fcd2c4a386",
-              "url": "https://files.pythonhosted.org/packages/e4/bd/cc36811c582d663a740fb45edf9f99ddbd99a10b6ba38267dc925e1e193a/grpcio-1.70.0-cp311-cp311-macosx_10_14_universal2.whl"
+              "hash": "d74c3f4f37b79e746271aa6cdb3a1d7e4432aea38735542b23adcabaaee0c097",
+              "url": "https://files.pythonhosted.org/packages/b0/cc/9c51109c71d068e4d474becf5f5d43c9d63038cec1b74112978000fa72f4/grpcio-1.73.1-cp311-cp311-macosx_11_0_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ba2cea9f7ae4bc21f42015f0ec98f69ae4179848ad744b210e7685112fa507a1",
+              "url": "https://files.pythonhosted.org/packages/e4/41/921565815e871d84043e73e2c0e748f0318dab6fa9be872cd042778f14a9/grpcio-1.73.1-cp311-cp311-linux_armv7l.whl"
             }
           ],
           "project_name": "grpcio",
           "requires_dists": [
-            "grpcio-tools>=1.70.0; extra == \"protobuf\""
+            "grpcio-tools>=1.73.1; extra == \"protobuf\""
           ],
-          "requires_python": ">=3.8",
-          "version": "1.70.0"
+          "requires_python": ">=3.9",
+          "version": "1.73.1"
         },
         {
           "artifacts": [
@@ -1400,6 +1406,24 @@
           "artifacts": [
             {
               "algorithm": "sha256",
+              "hash": "78d1bfc33b58a56697ef99e666e34be4c6887631341c75fdd28d58587aef5d9f",
+              "url": "https://files.pythonhosted.org/packages/b9/e2/9c682ba59a7f9cf477bc7954c25ce1c20f881693651f354d15df577996c0/types_grpcio-1.0.0.20250703-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "baf100184e5353cb60f045fb4fd47f37a360bedf0f19581535e4c3a3a1f7912b",
+              "url": "https://files.pythonhosted.org/packages/59/17/c80b7231e337993b808aef32bcc556aad60810ca51eeb7acd1204eefe518/types_grpcio-1.0.0.20250703.tar.gz"
+            }
+          ],
+          "project_name": "types-grpcio",
+          "requires_dists": [],
+          "requires_python": ">=3.9",
+          "version": "1.0.0.20250703"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
               "hash": "8b50294b55a9db89498cdc5a65b1b4545112b6cd1cf4465bd693d828b0282a17",
               "url": "https://files.pythonhosted.org/packages/47/be/b5e816c7299fa0a9f5b96ab7ae13920d51dfc90948b902de37935e0efa79/types_PyYAML-6.0.3-py3-none-any.whl"
             },
@@ -1594,7 +1618,7 @@
   "pip_version": "25.0",
   "prefer_older_binary": false,
   "requirements": [
-    "grpcio==1.70.0",
+    "grpcio==1.73.1",
     "httpx==0.28.1",
     "opentelemetry-api==1.34.1",
     "opentelemetry-exporter-otlp==1.34.1",
@@ -1604,7 +1628,8 @@
     "pantsbuild.pants.testutil==2.26.2",
     "pantsbuild.pants==2.26.2",
     "pytest",
-    "toml==0.10.2"
+    "toml==0.10.2",
+    "types-grpcio==1.0.0.20250703"
   ],
   "requires_python": [
     "==3.11.*"

--- a/3rdparty/python/pants-2.26.txt
+++ b/3rdparty/python/pants-2.26.txt
@@ -12,5 +12,6 @@ pytest
 toml==0.10.2
 httpx==0.28.1
 opentelemetry-proto==1.34.1
-grpcio==1.70.0
+grpcio==1.73.1
+types-grpcio==1.0.0.20250703
 packaging  # match version in Pants repository

--- a/3rdparty/python/pants-2.27.lock
+++ b/3rdparty/python/pants-2.27.lock
@@ -9,7 +9,7 @@
 //     "CPython==3.11.*"
 //   ],
 //   "generated_with_requirements": [
-//     "grpcio==1.70.0",
+//     "grpcio==1.73.1",
 //     "httpx==0.28.1",
 //     "opentelemetry-api==1.34.1",
 //     "opentelemetry-exporter-otlp==1.34.1",
@@ -19,7 +19,8 @@
 //     "pantsbuild.pants.testutil==2.27.0",
 //     "pantsbuild.pants==2.27.0",
 //     "pytest",
-//     "toml==0.10.2"
+//     "toml==0.10.2",
+//     "types-grpcio==1.0.0.20250703"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -158,19 +159,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
-              "url": "https://files.pythonhosted.org/packages/84/ae/320161bd181fc06471eed047ecce67b693fd7515b16d495d8932db763426/certifi-2025.6.15-py3-none-any.whl"
+              "hash": "d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39",
+              "url": "https://files.pythonhosted.org/packages/66/f3/80a3f974c8b535d394ff960a11ac20368e06b736da395b551a49ce950cce/certifi-2025.7.9-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b",
-              "url": "https://files.pythonhosted.org/packages/73/f7/f14b46d4bcd21092d7d3ccef689615220d8a08fb25e564b65d20738e672e/certifi-2025.6.15.tar.gz"
+              "hash": "c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079",
+              "url": "https://files.pythonhosted.org/packages/de/8a/c729b6b60c66a38f590c4e774decc4b2ec7b0576be8f1aa984a53ffa812a/certifi-2025.7.9.tar.gz"
             }
           ],
           "project_name": "certifi",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "2025.6.15"
+          "version": "2025.7.9"
         },
         {
           "artifacts": [
@@ -309,51 +310,56 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d63764963412e22f0491d0d32833d71087288f4e24cbcddbae82476bfa1d81fd",
-              "url": "https://files.pythonhosted.org/packages/4c/c4/684d877517e5bfd6232d79107e5a1151b835e9f99051faef51fed3359ec4/grpcio-1.70.0-cp311-cp311-musllinux_1_1_x86_64.whl"
+              "hash": "610e19b04f452ba6f402ac9aa94eb3d21fbc94553368008af634812c4a85a99e",
+              "url": "https://files.pythonhosted.org/packages/42/72/a13ff7ba6c68ccffa35dacdc06373a76c0008fd75777cba84d7491956620/grpcio-1.73.1-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "27cc75e22c5dba1fbaf5a66c778e36ca9b8ce850bf58a9db887754593080d839",
-              "url": "https://files.pythonhosted.org/packages/05/33/dbf035bc6d167068b4a9f2929dfe0b03fb763f0f861ecb3bb1709a14cb65/grpcio-1.70.0-cp311-cp311-musllinux_1_1_i686.whl"
+              "hash": "bc5eccfd9577a5dc7d5612b2ba90cca4ad14c6d949216c68585fdec9848befb1",
+              "url": "https://files.pythonhosted.org/packages/0e/64/12d6dc446021684ee1428ea56a3f3712048a18beeadbdefa06e6f8814a6e/grpcio-1.73.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "17325b0be0c068f35770f944124e8839ea3185d6d54862800fc28cc2ffad205a",
-              "url": "https://files.pythonhosted.org/packages/65/c4/1f67d23d6bcadd2fd61fb460e5969c52b3390b4a4e254b5e04a6d1009e5e/grpcio-1.70.0-cp311-cp311-linux_armv7l.whl"
+              "hash": "105492124828911f85127e4825d1c1234b032cb9d238567876b5515d01151379",
+              "url": "https://files.pythonhosted.org/packages/38/64/02c83b5076510784d1305025e93e0d78f53bb6a0213c8c84cfe8a00c5c48/grpcio-1.73.1-cp311-cp311-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8d1584a68d5922330025881e63a6c1b54cc8117291d382e4fa69339b6d914c56",
-              "url": "https://files.pythonhosted.org/packages/69/e1/4b21b5017c33f3600dcc32b802bb48fe44a4d36d6c066f52650c7c2690fa/grpcio-1.70.0.tar.gz"
+              "hash": "b3215f69a0670a8cfa2ab53236d9e8026bfb7ead5d4baabe7d7dc11d30fda967",
+              "url": "https://files.pythonhosted.org/packages/5d/47/36deacd3c967b74e0265f4c608983e897d8bb3254b920f8eafdf60e4ad7e/grpcio-1.73.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5ea67c72101d687d44d9c56068328da39c9ccba634cabb336075fae2eab0d04b",
-              "url": "https://files.pythonhosted.org/packages/7e/32/8538bb2ace5cd72da7126d1c9804bf80b4fe3be70e53e2d55675c24961a8/grpcio-1.70.0-cp311-cp311-manylinux_2_17_aarch64.whl"
+              "hash": "dc7d7fd520614fce2e6455ba89791458020a39716951c7c07694f9dbae28e9c0",
+              "url": "https://files.pythonhosted.org/packages/72/4b/6bae2d88a006000f1152d2c9c10ffd41d0131ca1198e0b661101c2e30ab9/grpcio-1.73.1-cp311-cp311-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e7831a0fc1beeeb7759f737f5acd9fdcda520e955049512d68fda03d91186eea",
-              "url": "https://files.pythonhosted.org/packages/9f/e5/5316b239380b8b2ad30373eb5bb25d9fd36c0375e94a98a0a60ea357d254/grpcio-1.70.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "7fce2cd1c0c1116cf3850564ebfc3264fba75d3c74a7414373f1238ea365ef87",
+              "url": "https://files.pythonhosted.org/packages/79/e8/b43b851537da2e2f03fa8be1aef207e5cbfb1a2e014fbb6b40d24c177cd3/grpcio-1.73.1.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "cb5277db254ab7586769e490b7b22f4ddab3876c490da0a1a9d7c695ccf0bf77",
-              "url": "https://files.pythonhosted.org/packages/ce/5c/a45f85f2a0dfe4a6429dee98717e0e8bd7bd3f604315493c39d9679ca065/grpcio-1.70.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "5b9b1805a7d61c9e90541cbe8dfe0a593dfc8c5c3a43fe623701b6a01b01d710",
+              "url": "https://files.pythonhosted.org/packages/8f/d3/33d738a06f6dbd4943f4d377468f8299941a7c8c6ac8a385e4cef4dd3c93/grpcio-1.73.1-cp311-cp311-manylinux_2_17_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dbe41ad140df911e796d4463168e33ef80a24f5d21ef4d1e310553fcd2c4a386",
-              "url": "https://files.pythonhosted.org/packages/e4/bd/cc36811c582d663a740fb45edf9f99ddbd99a10b6ba38267dc925e1e193a/grpcio-1.70.0-cp311-cp311-macosx_10_14_universal2.whl"
+              "hash": "d74c3f4f37b79e746271aa6cdb3a1d7e4432aea38735542b23adcabaaee0c097",
+              "url": "https://files.pythonhosted.org/packages/b0/cc/9c51109c71d068e4d474becf5f5d43c9d63038cec1b74112978000fa72f4/grpcio-1.73.1-cp311-cp311-macosx_11_0_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ba2cea9f7ae4bc21f42015f0ec98f69ae4179848ad744b210e7685112fa507a1",
+              "url": "https://files.pythonhosted.org/packages/e4/41/921565815e871d84043e73e2c0e748f0318dab6fa9be872cd042778f14a9/grpcio-1.73.1-cp311-cp311-linux_armv7l.whl"
             }
           ],
           "project_name": "grpcio",
           "requires_dists": [
-            "grpcio-tools>=1.70.0; extra == \"protobuf\""
+            "grpcio-tools>=1.73.1; extra == \"protobuf\""
           ],
-          "requires_python": ">=3.8",
-          "version": "1.70.0"
+          "requires_python": ">=3.9",
+          "version": "1.73.1"
         },
         {
           "artifacts": [
@@ -1461,6 +1467,24 @@
           "artifacts": [
             {
               "algorithm": "sha256",
+              "hash": "78d1bfc33b58a56697ef99e666e34be4c6887631341c75fdd28d58587aef5d9f",
+              "url": "https://files.pythonhosted.org/packages/b9/e2/9c682ba59a7f9cf477bc7954c25ce1c20f881693651f354d15df577996c0/types_grpcio-1.0.0.20250703-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "baf100184e5353cb60f045fb4fd47f37a360bedf0f19581535e4c3a3a1f7912b",
+              "url": "https://files.pythonhosted.org/packages/59/17/c80b7231e337993b808aef32bcc556aad60810ca51eeb7acd1204eefe518/types_grpcio-1.0.0.20250703.tar.gz"
+            }
+          ],
+          "project_name": "types-grpcio",
+          "requires_dists": [],
+          "requires_python": ">=3.9",
+          "version": "1.0.0.20250703"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
               "hash": "8b50294b55a9db89498cdc5a65b1b4545112b6cd1cf4465bd693d828b0282a17",
               "url": "https://files.pythonhosted.org/packages/47/be/b5e816c7299fa0a9f5b96ab7ae13920d51dfc90948b902de37935e0efa79/types_PyYAML-6.0.3-py3-none-any.whl"
             },
@@ -1655,7 +1679,7 @@
   "pip_version": "25.0",
   "prefer_older_binary": false,
   "requirements": [
-    "grpcio==1.70.0",
+    "grpcio==1.73.1",
     "httpx==0.28.1",
     "opentelemetry-api==1.34.1",
     "opentelemetry-exporter-otlp==1.34.1",
@@ -1665,7 +1689,8 @@
     "pantsbuild.pants.testutil==2.27.0",
     "pantsbuild.pants==2.27.0",
     "pytest",
-    "toml==0.10.2"
+    "toml==0.10.2",
+    "types-grpcio==1.0.0.20250703"
   ],
   "requires_python": [
     "==3.11.*"

--- a/3rdparty/python/pants-2.27.txt
+++ b/3rdparty/python/pants-2.27.txt
@@ -12,5 +12,6 @@ pytest
 toml==0.10.2
 httpx==0.28.1
 opentelemetry-proto==1.34.1
-grpcio==1.70.0
+grpcio==1.73.1
+types-grpcio==1.0.0.20250703
 packaging  # match version in Pants repository

--- a/3rdparty/python/pytest.lock
+++ b/3rdparty/python/pytest.lock
@@ -124,58 +124,58 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "726f32ee3713f7359696331a18daf0c3b3a70bb0ae71141b9d3c52be7c595e32",
-              "url": "https://files.pythonhosted.org/packages/a0/1a/0b9c32220ad694d66062f571cc5cedfa9997b64a591e8a500bb63de1bd40/coverage-7.8.2-py3-none-any.whl"
+              "hash": "e425cd5b00f6fc0ed7cdbd766c70be8baab4b7839e4d4fe5fac48581dd968ea4",
+              "url": "https://files.pythonhosted.org/packages/3c/38/bbe2e63902847cf79036ecc75550d0698af31c91c7575352eb25190d0fb3/coverage-7.9.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "07a989c867986c2a75f158f03fdb413128aad29aca9d4dbce5fc755672d96f11",
-              "url": "https://files.pythonhosted.org/packages/06/58/38c676aec594bfe2a87c7683942e5a30224791d8df99bcc8439fde140377/coverage-7.8.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "997024fa51e3290264ffd7492ec97d0690293ccd2b45a6cd7d82d945a4a80c8b",
+              "url": "https://files.pythonhosted.org/packages/04/b7/c0465ca253df10a9e8dae0692a4ae6e9726d245390aaef92360e1d6d3832/coverage-7.9.2.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "ef2f22795a7aca99fc3c84393a55a53dd18ab8c93fb431004e4d8f0774150f54",
-              "url": "https://files.pythonhosted.org/packages/4d/82/40e55f7c0eb5e97cc62cbd9d0746fd24e8caf57be5a408b87529416e0c70/coverage-7.8.2-cp311-cp311-musllinux_1_2_x86_64.whl"
+              "hash": "333b2e0ca576a7dbd66e85ab402e35c03b0b22f525eed82681c4b866e2e2653a",
+              "url": "https://files.pythonhosted.org/packages/0f/3c/d56a764b2e5a3d43257c36af4a62c379df44636817bb5f89265de4bf8bd7/coverage-7.9.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e6ea7dba4e92926b7b5f0990634b78ea02f208d04af520c73a7c876d5a8d36cb",
-              "url": "https://files.pythonhosted.org/packages/57/37/0ae95989285a39e0839c959fe854a3ae46c06610439350d1ab860bf020ac/coverage-7.8.2-cp311-cp311-musllinux_1_2_i686.whl"
+              "hash": "a7a56a2964a9687b6aba5b5ced6971af308ef6f79a91043c05dd4ee3ebc3e9ba",
+              "url": "https://files.pythonhosted.org/packages/39/40/916786453bcfafa4c788abee4ccd6f592b5b5eca0cd61a32a4e5a7ef6e02/coverage-7.9.2-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ec455eedf3ba0bbdf8f5a570012617eb305c63cb9f03428d39bf544cb2b94837",
-              "url": "https://files.pythonhosted.org/packages/69/2f/572b29496d8234e4a7773200dd835a0d32d9e171f2d974f3fe04a9dbc271/coverage-7.8.2-pp39.pp310.pp311-none-any.whl"
+              "hash": "19e7be4cfec248df38ce40968c95d3952fbffd57b400d4b9bb580f28179556d2",
+              "url": "https://files.pythonhosted.org/packages/43/02/d91992c2b29bc7afb729463bc918ebe5f361be7f1daae93375a5759d1e28/coverage-7.9.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b99058eef42e6a8dcd135afb068b3d53aff3921ce699e127602efff9956457a9",
-              "url": "https://files.pythonhosted.org/packages/6a/4d/1ff618ee9f134d0de5cc1661582c21a65e06823f41caf801aadf18811a8e/coverage-7.8.2-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "2c8937fa16c8c9fbbd9f118588756e7bcdc7e16a470766a9aef912dd3f117dbd",
+              "url": "https://files.pythonhosted.org/packages/9b/d2/e0be7446a2bba11739edb9f9ba4eff30b30d8257370e237418eb44a14d11/coverage-7.9.2-cp311-cp311-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2db10dedeb619a771ef0e2949ccba7b75e33905de959c2643a4607bef2f3fb3a",
-              "url": "https://files.pythonhosted.org/packages/80/0c/95b1023e881ce45006d9abc250f76c6cdab7134a1c182d9713878dfefcb2/coverage-7.8.2-cp311-cp311-musllinux_1_2_aarch64.whl"
+              "hash": "42da2280c4d30c57a9b578bafd1d4494fa6c056d4c419d9689e66d775539be74",
+              "url": "https://files.pythonhosted.org/packages/9d/7d/dcbac9345000121b8b57a3094c2dfcf1ccc52d8a14a40c1d4bc89f936f80/coverage-7.9.2-cp311-cp311-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5feb7f2c3e6ea94d3b877def0270dff0947b8d8c04cfa34a17be0a4dc1836879",
-              "url": "https://files.pythonhosted.org/packages/96/fa/c3c1b476de96f2bc7a8ca01a9f1fcb51c01c6b60a9d2c3e66194b2bdb4af/coverage-7.8.2-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "123d589f32c11d9be7fe2e66d823a236fe759b0096f5db3fb1b75b2fa414a4fa",
+              "url": "https://files.pythonhosted.org/packages/9f/66/cc13bae303284b546a030762957322bbbff1ee6b6cb8dc70a40f8a78512f/coverage-7.9.2-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a886d531373a1f6ff9fad2a2ba4a045b68467b779ae729ee0b3b10ac20033b27",
-              "url": "https://files.pythonhosted.org/packages/ba/07/998afa4a0ecdf9b1981ae05415dad2d4e7716e1b1f00abbd91691ac09ac9/coverage-7.8.2.tar.gz"
+              "hash": "326802760da234baf9f2f85a39e4a4b5861b94f6c8d95251f699e4f73b1835dc",
+              "url": "https://files.pythonhosted.org/packages/b1/46/bd064ea8b3c94eb4ca5d90e34d15b806cba091ffb2b8e89a0d7066c45791/coverage-7.9.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0bdc8bf760459a4a4187b452213e04d039990211f98644c7292adf1e471162b5",
-              "url": "https://files.pythonhosted.org/packages/cd/46/1ae01912dfb06a642ef3dd9cf38ed4996fda8fe884dab8952da616f81a2b/coverage-7.8.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "0b4a4cb73b9f2b891c1788711408ef9707666501ba23684387277ededab1097c",
+              "url": "https://files.pythonhosted.org/packages/b7/4f/8fadff6bf56595a16d2d6e33415841b0163ac660873ed9a4e9046194f779/coverage-7.9.2-cp311-cp311-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "670a13249b957bb9050fab12d86acef7bf8f6a879b9d1a883799276e0d4c674a",
-              "url": "https://files.pythonhosted.org/packages/f7/c2/5414c5a1b286c0f3881ae5adb49be1854ac5b7e99011501f81c8c1453065/coverage-7.8.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "8a1166db2fb62473285bcb092f586e081e92656c7dfa8e9f62b4d39d7e6b5050",
+              "url": "https://files.pythonhosted.org/packages/d7/85/f8bbefac27d286386961c25515431482a425967e23d3698b75a250872924/coverage-7.9.2-pp39.pp310.pp311-none-any.whl"
             }
           ],
           "project_name": "coverage",
@@ -183,7 +183,7 @@
             "tomli; python_full_version <= \"3.11.0a6\" and extra == \"toml\""
           ],
           "requires_python": ">=3.9",
-          "version": "7.8.2"
+          "version": "7.9.2"
         },
         {
           "artifacts": [
@@ -329,13 +329,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "fef5e33c4a1ae0759e0bba5917c9db4eb8c53fee917b6a526bd973e1ca5159f6",
-              "url": "https://files.pythonhosted.org/packages/78/ce/5e897ee51b7d26ab4e47e5105e7368d40ce6cfae2367acdf3165396d50be/ipython-9.2.0-py3-none-any.whl"
+              "hash": "25850f025a446d9b359e8d296ba175a36aedd32e83ca9b5060430fe16801f066",
+              "url": "https://files.pythonhosted.org/packages/63/f8/0031ee2b906a15a33d6bfc12dd09c3dfa966b3cb5b284ecfb7549e6ac3c4/ipython-9.4.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "62a9373dbc12f28f9feaf4700d052195bf89806279fc8ca11f3f54017d04751b",
-              "url": "https://files.pythonhosted.org/packages/9d/02/63a84444a7409b3c0acd1de9ffe524660e0e5d82ee473e78b45e5bfb64a4/ipython-9.2.0.tar.gz"
+              "hash": "c033c6d4e7914c3d9768aabe76bbe87ba1dc66a92a05db6bfa1125d81f2ee270",
+              "url": "https://files.pythonhosted.org/packages/54/80/406f9e3bde1c1fd9bf5a0be9d090f8ae623e401b7670d8f6fdf2ab679891/ipython-9.4.0.tar.gz"
             }
           ],
           "project_name": "ipython",
@@ -381,7 +381,7 @@
             "typing_extensions>=4.6; python_version < \"3.12\""
           ],
           "requires_python": ">=3.11",
-          "version": "9.2.0"
+          "version": "9.4.0"
         },
         {
           "artifacts": [
@@ -734,13 +734,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c",
-              "url": "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl"
+              "hash": "86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b",
+              "url": "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f",
-              "url": "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz"
+              "hash": "636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887",
+              "url": "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz"
             }
           ],
           "project_name": "pygments",
@@ -748,7 +748,7 @@
             "colorama>=0.4.6; extra == \"windows-terminal\""
           ],
           "requires_python": ">=3.8",
-          "version": "2.19.1"
+          "version": "2.19.2"
         },
         {
           "artifacts": [
@@ -1100,19 +1100,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c",
-              "url": "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl"
+              "hash": "d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76",
+              "url": "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef",
-              "url": "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz"
+              "hash": "38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36",
+              "url": "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
-          "requires_python": ">=3.8",
-          "version": "4.13.2"
+          "requires_python": ">=3.9",
+          "version": "4.14.1"
         },
         {
           "artifacts": [
@@ -1142,7 +1142,7 @@
   "only_wheels": [],
   "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.33.9",
+  "pex_version": "2.40.2",
   "pip_version": "25.0",
   "prefer_older_binary": false,
   "requirements": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,3 +77,7 @@ The plugin uses the `shoalsoft-opentelemetry` options scope. Key options:
 - isort import sorting  
 - flake8 linting with custom config in `build-support/flake8/.flake8`
 - mypy type checking with strict settings
+
+## Development Workflow
+
+- When testing changes, first check formatting, linting, and type checking via the Pants `fmt`, `lint`, and `check` goals respectively. Then run tests using the Pants `test` goal. Do not attempt to run tests directly using `pytest` since Pants supplies the execution environment.

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/BUILD
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/BUILD
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PLUGIN_VERSION = "0.2.2"
+PLUGIN_VERSION = "0.2.1"
 
 PANTS_MAJOR_MINOR_VERSIONS = ["2.27", "2.26", "2.25"]
 
 python_sources(
+    sources=["*.py", "!*_test_server.py", "!*_test.py", "!*_integration_test.py"],
+    overrides={
+        "subprocess_processor.py": dict(
+            dependencies=["./otlp_grpc_subprocess_processor_server.py"],
+        )
+    },
     **parametrize(
         "pants-2.27",
         resolve="pants-2.27",
@@ -58,8 +64,30 @@ python_tests(
             for pants_version in PANTS_MAJOR_MINOR_VERSIONS
         ),
     ],
+    overrides={
+        "opentelemetry_integration_test.py": dict(
+            dependencies=["./otlp_grpc_test_server.py:test_utils"],
+        )
+    },
     # Integration tests take forever given how they are run. :(
     timeout=600,
+)
+
+python_sources(
+    name="test_utils",
+    sources=["*_test_server.py"],
+    **parametrize(
+        "pants-2.27",
+        resolve="pants-2.27",
+    ),
+    **parametrize(
+        "pants-2.26",
+        resolve="pants-2.26",
+    ),
+    **parametrize(
+        "pants-2.25",
+        resolve="pants-2.25",
+    ),
 )
 
 pex_binary(

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/BUILD
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PLUGIN_VERSION = "0.2.1"
+PLUGIN_VERSION = "0.2.2"
 
 PANTS_MAJOR_MINOR_VERSIONS = ["2.27", "2.26", "2.25"]
 

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/exception_logging_processor.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/exception_logging_processor.py
@@ -38,7 +38,7 @@ class ExceptionLoggingProcessor(Processor):
     @contextmanager
     def _wrapper(self) -> Generator[None, None, None]:
         try:
-            yield
+            return (yield)
         except Exception as ex:
             logger.debug(
                 f"An exception occurred while processing a workunit in the {self._name} workunit tracing handler: {ex}",

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/exception_logging_processor.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/exception_logging_processor.py
@@ -38,7 +38,7 @@ class ExceptionLoggingProcessor(Processor):
     @contextmanager
     def _wrapper(self) -> Generator[None, None, None]:
         try:
-            return (yield)
+            yield
         except Exception as ex:
             logger.debug(
                 f"An exception occurred while processing a workunit in the {self._name} workunit tracing handler: {ex}",

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/message_protocol.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/message_protocol.py
@@ -1,0 +1,131 @@
+# Copyright (C) 2025 Shoal Software LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import enum
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from pants.util.frozendict import FrozenDict
+from shoalsoft.pants_opentelemetry_plugin.processor import IncompleteWorkunit, Workunit
+
+
+class ProcessorOperation(enum.Enum):
+    INITIALIZE = "initialize"
+    START_WORKUNIT = "start_workunit"
+    COMPLETE_WORKUNIT = "complete_workunit"
+    FINISH = "finish"
+    SHUTDOWN = "shutdown"
+
+
+@dataclass(frozen=True)
+class OtelParameters:
+    endpoint: str | None
+    certificate_file: str | None
+    client_key_file: str | None
+    client_certificate_file: str | None
+    headers: Mapping[str, str] | None
+    timeout: int | None
+    compression: str | None
+    insecure: bool | None
+
+    def to_args_for_subprocess(self) -> list[str]:
+        args = []
+        if self.endpoint is not None:
+            args.extend(["--endpoint", self.endpoint])
+        if self.certificate_file is not None:
+            args.extend(["--certificate_file", self.certificate_file])
+        if self.client_key_file is not None:
+            args.extend(["--client_key_file", self.client_key_file])
+        if self.client_certificate_file is not None:
+            args.extend(["--client_certificate_file", self.client_certificate_file])
+        if self.headers is not None:
+            args.extend(["--headers", json.dumps(self.headers)])
+        if self.timeout is not None:
+            args.extend(["--timeout", str(self.timeout)])
+        if self.compression is not None:
+            args.extend(["--compression", self.compression])
+        if self.insecure is not None:
+            args.append("--insecure" if self.insecure else "--no-insecure")
+        return args
+
+    @classmethod
+    def from_parsed_options(cls, options: argparse.Namespace) -> OtelParameters:
+        return cls(
+            endpoint=options.endpoint if options.endpoint is not None else None,
+            certificate_file=(
+                options.certificate_file if options.certificate_file is not None else None
+            ),
+            client_key_file=(
+                options.client_key_file if options.client_key_file is not None else None
+            ),
+            client_certificate_file=(
+                options.client_certificate_file
+                if options.client_certificate_file is not None
+                else None
+            ),
+            headers=json.loads(options.headers) if options.headers is not None else None,
+            timeout=options.timeout if options.timeout is not None else None,
+            compression=options.compression if options.compression is not None else None,
+            insecure=options.insecure if options.insecure is not None else None,
+        )
+
+    @staticmethod
+    def add_options_to_parser(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--endpoint", default=None, action="store")
+        parser.add_argument("--certificate_file", default=None, action="store")
+        parser.add_argument("--client_key_file", default=None, action="store")
+        parser.add_argument("--client_certificate_file", default=None, action="store")
+        parser.add_argument("--headers", default=None, action="store")
+        parser.add_argument("--timeout", default=None, type=int, action="store")
+        parser.add_argument("--compression", default=None, action="store")
+        parser.add_argument("--insecure", action="store_true")
+
+
+@dataclass(frozen=True)
+class InitializeData:
+    otel_parameters: OtelParameters
+    build_root: str
+    traceparent_env_var: str | None
+
+
+@dataclass(frozen=True)
+class StartWorkunitData:
+    workunit: IncompleteWorkunit
+    context_metrics: FrozenDict[str, int]
+
+
+@dataclass(frozen=True)
+class CompleteWorkunitData:
+    workunit: Workunit
+    context_metrics: FrozenDict[str, int]
+
+
+@dataclass(frozen=True)
+class FinishData:
+    timeout_seconds: float | None
+    context_metrics: FrozenDict[str, int]
+
+
+ProcessorMessageDataT = InitializeData | StartWorkunitData | CompleteWorkunitData | FinishData
+
+
+@dataclass(frozen=True)
+class ProcessorMessage:
+    operation: ProcessorOperation
+    data: ProcessorMessageDataT
+    sequence_id: int

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry_integration_test.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry_integration_test.py
@@ -470,16 +470,16 @@ def test_opentelemetry_integration(subtests, pants_version_str: str) -> None:
         )
         result.assert_success()
 
-    with subtests.test(msg="OTLP/GRPC span exporter"):
-        do_test_of_otlp_grpc_exporter(
+    with subtests.test(msg="OTLP/HTTP span exporter"):
+        do_test_of_otlp_http_exporter(
             buildroot=buildroot,
             pants_exe_args=pants_exe_args,
             workdir_base=workdir_base,
             extra_env=extra_env,
         )
 
-    with subtests.test(msg="OTLP/HTTP span exporter"):
-        do_test_of_otlp_http_exporter(
+    with subtests.test(msg="OTLP/GRPC span exporter"):
+        do_test_of_otlp_grpc_exporter(
             buildroot=buildroot,
             pants_exe_args=pants_exe_args,
             workdir_base=workdir_base,

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry_integration_test.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry_integration_test.py
@@ -14,25 +14,27 @@
 
 from __future__ import annotations
 
+import base64
 import json
+import logging
 import os
+import queue
 import subprocess
+import sys
 import tempfile
 import textwrap
 import threading
 import time
 import typing
-from concurrent import futures
 from dataclasses import dataclass
 from functools import partial
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import IO, Any, Iterable, Mapping
 
-import grpc  # type: ignore[import-untyped]
 import httpx
 import pytest
-from opentelemetry.proto.collector.trace.v1 import trace_service_pb2, trace_service_pb2_grpc
+from opentelemetry.proto.collector.trace.v1 import trace_service_pb2
 from opentelemetry.proto.common.v1 import common_pb2
 from opentelemetry.proto.trace.v1 import trace_pb2
 from packaging.version import Version
@@ -41,6 +43,8 @@ from pants.testutil.python_interpreter_selection import python_interpreter_path
 from pants.util.dirutil import safe_file_dump
 from shoalsoft.pants_opentelemetry_plugin.pants_integration_testutil import run_pants_with_workdir
 from shoalsoft.pants_opentelemetry_plugin.subsystem import TracingExporterId
+
+logger = logging.getLogger(__name__)
 
 
 def _safe_write_files(base_path: str | os.PathLike, files: Mapping[str, str | bytes]) -> None:
@@ -189,7 +193,7 @@ def do_test_of_otlp_http_exporter(
         result.assert_success()
 
         # Assert that tracing spans were received over HTTP.
-        assert len(recorded_requests) > 0
+        assert len(recorded_requests) > 0, "No trace requests received!"
 
         def _convert(body: bytes) -> trace_service_pb2.ExportTraceServiceRequest:
             trace_request = trace_service_pb2.ExportTraceServiceRequest()
@@ -199,17 +203,6 @@ def do_test_of_otlp_http_exporter(
         _assert_trace_requests([_convert(request.body) for request in recorded_requests])
 
 
-class _TraceServiceImpl(trace_service_pb2_grpc.TraceServiceServicer):
-    def __init__(self, requests: list[trace_service_pb2.ExportTraceServiceRequest]) -> None:
-        self.requests = requests
-
-    def Export(
-        self, request: trace_service_pb2.ExportTraceServiceRequest, context
-    ) -> trace_service_pb2.ExportTraceServiceResponse:
-        self.requests.append(request)
-        return trace_service_pb2.ExportTraceServiceResponse()
-
-
 def do_test_of_otlp_grpc_exporter(
     *,
     buildroot: Path,
@@ -217,45 +210,122 @@ def do_test_of_otlp_grpc_exporter(
     workdir_base: Path,
     extra_env: Mapping[str, str] | None = None,
 ) -> None:
-    received_requests: list[trace_service_pb2.ExportTraceServiceRequest] = []
-    server_impl = _TraceServiceImpl(received_requests)
+    # Start a subprocess with a test server to receive OpenTelemetry spans. Because of the fork safety issues with the
+    # gRPC C library wrapped by the `grpcio` Python module, gRPC-related logic should be invoked in a process which
+    # will not fork once gRPC is in use.
+    script_path = Path(__file__).parent.joinpath("otlp_grpc_test_server.py")
+    assert script_path.exists(), "gRPC test server script is not available."
+    test_server_process = subprocess.Popen(
+        [sys.executable, str(script_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={
+            "PYTHONPATH": ":".join(sys.path),
+            "PYTHONUNBUFFERED": "1",
+            "GRPC_VERBOSITY": "DEBUG",
+        },
+    )
+    output_queue: queue.Queue[str] = queue.Queue()
+    error_queue: queue.Queue[str] = queue.Queue()
 
-    grpc_server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
-    trace_service_pb2_grpc.add_TraceServiceServicer_to_server(server_impl, grpc_server)
-    server_port = grpc_server.add_insecure_port("127.0.0.1:0")
-    grpc_server.start()
+    def worker(stream: IO[bytes], queue: queue.Queue[str], log: bool = False) -> None:
+        while True:
+            line = stream.readline()
+            if not line:
+                break
+            if log:
+                logger.info("")
+            queue.put_nowait(line.decode("utf-8").strip())
 
-    sources = {
-        "otlp-grpc/BUILD": "python_sources(name='src')\n",
-        "otlp-grpc/main.py": "print('Hello World!)\n",
-    }
-    with tempfile.TemporaryDirectory(dir=workdir_base) as workdir:
-        _safe_write_files(buildroot, sources)
+    stdout_reader_thread = threading.Thread(
+        target=worker, args=(test_server_process.stdout, output_queue)
+    )
+    stdout_reader_thread.daemon = True
+    stdout_reader_thread.start()
 
-        result = run_pants_with_workdir(
-            [
-                "--shoalsoft-opentelemetry-enabled",
-                f"--shoalsoft-opentelemetry-exporter={TracingExporterId.GRPC.value}",
-                f"--shoalsoft-opentelemetry-exporter-endpoint=http://127.0.0.1:{server_port}/",
-                "--shoalsoft-opentelemetry-exporter-insecure",
-                "list",
-                "otlp-grpc::",
-            ],
-            pants_exe_args=pants_exe_args,
-            workdir=workdir,
-            extra_env={
-                **(extra_env if extra_env else {}),
-                "PANTS_BUILDROOT_OVERRIDE": str(buildroot),
-                "GRPC_VERBOSITY": "DEBUG",
-                "TRACEPARENT": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-00",
-            },
-            cwd=buildroot,
-        )
-        result.assert_success()
+    stderr_reader_thread = threading.Thread(
+        target=worker, args=(test_server_process.stderr, error_queue)
+    )
+    stderr_reader_thread.daemon = True
+    stderr_reader_thread.start()
 
-        # Assert that tracing spans were received over HTTP.
-        assert len(received_requests) > 0
-        _assert_trace_requests(received_requests)
+    try:
+        # The server's listening port is written as the first output line.
+        server_port: int
+        try:
+            server_port_str = output_queue.get(timeout=5.0)
+            server_port = int(server_port_str)
+        except queue.Empty:
+            raise AssertionError("gRPC test server failed to start within timeout.")
+
+        sources = {
+            "otlp-grpc/BUILD": "python_sources(name='src')\n",
+            "otlp-grpc/main.py": "print('Hello World!')\n",
+        }
+        with tempfile.TemporaryDirectory(dir=workdir_base) as workdir:
+            _safe_write_files(buildroot, sources)
+
+            # Test the gRPC exporter configuration with actual gRPC server
+            result = run_pants_with_workdir(
+                [
+                    "--shoalsoft-opentelemetry-enabled",
+                    f"--shoalsoft-opentelemetry-exporter={TracingExporterId.GRPC.value}",
+                    f"--shoalsoft-opentelemetry-exporter-endpoint=http://127.0.0.1:{server_port}",
+                    "--shoalsoft-opentelemetry-exporter-insecure",
+                    "--shoalsoft-opentelemetry-finish-timeout=5",  # Allow time for export
+                    "-ldebug",
+                    "list",
+                    "otlp-grpc::",
+                ],
+                pants_exe_args=pants_exe_args,
+                workdir=workdir,
+                extra_env={
+                    **(extra_env if extra_env else {}),
+                    "PANTS_BUILDROOT_OVERRIDE": str(buildroot),
+                    "TRACEPARENT": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-00",
+                },
+                cwd=buildroot,
+                stream_output=True,
+                use_pantsd=False,
+            )
+
+            # The command should succeed.
+            result.assert_success()
+
+            # Collect all of the trace reqyests sent to the test server.
+            received_requests: list[trace_service_pb2.ExportTraceServiceRequest] = []
+            while True:
+                try:
+                    trace_request_str = output_queue.get(timeout=0.25)
+                    trace_request = trace_service_pb2.ExportTraceServiceRequest()
+                    trace_request.ParseFromString(
+                        base64.b64decode(trace_request_str, validate=True)
+                    )
+                    received_requests.append(trace_request)
+                except queue.Empty:
+                    break
+
+            # Assert that tracing spans were received over HTTP.
+            assert len(received_requests) > 0, "No trace requests received!"
+
+            _assert_trace_requests(received_requests)
+
+    finally:
+        test_server_process.kill()
+        test_server_process.wait(timeout=1.0)
+
+        error_messages: list[str] = []
+        while True:
+            try:
+                error_str = error_queue.get(timeout=0.25)
+                error_messages.append(error_str)
+            except queue.Empty:
+                break
+
+        joined_error_messages = "\n".join(error_messages)
+        if joined_error_messages:
+            print("gRPC test server returned stderr output:\n\n" + joined_error_messages)
+            assert "TEST-ERROR" not in joined_error_messages, "gRPC test server signalled an error"
 
 
 def do_test_of_json_file_exporter(
@@ -400,16 +470,16 @@ def test_opentelemetry_integration(subtests, pants_version_str: str) -> None:
         )
         result.assert_success()
 
-    with subtests.test(msg="OTLP/HTTP span exporter"):
-        do_test_of_otlp_http_exporter(
+    with subtests.test(msg="OTLP/GRPC span exporter"):
+        do_test_of_otlp_grpc_exporter(
             buildroot=buildroot,
             pants_exe_args=pants_exe_args,
             workdir_base=workdir_base,
             extra_env=extra_env,
         )
 
-    with subtests.test(msg="OTLP/GRPC span exporter"):
-        do_test_of_otlp_grpc_exporter(
+    with subtests.test(msg="OTLP/HTTP span exporter"):
+        do_test_of_otlp_http_exporter(
             buildroot=buildroot,
             pants_exe_args=pants_exe_args,
             workdir_base=workdir_base,

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/otlp_grpc_subprocess_processor_server.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/otlp_grpc_subprocess_processor_server.py
@@ -1,0 +1,228 @@
+# Copyright (C) 2025 Shoal Software LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import logging
+import os
+import pickle
+import queue
+import struct
+import sys
+import threading
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from pants.util.frozendict import FrozenDict
+from shoalsoft.pants_opentelemetry_plugin.message_protocol import (
+    CompleteWorkunitData,
+    FinishData,
+    InitializeData,
+    OtelParameters,
+    ProcessorMessage,
+    ProcessorOperation,
+    StartWorkunitData,
+)
+from shoalsoft.pants_opentelemetry_plugin.opentelemetry_processor import get_processor
+from shoalsoft.pants_opentelemetry_plugin.processor import Processor, ProcessorContext
+from shoalsoft.pants_opentelemetry_plugin.subsystem import TracingExporterId
+
+
+class _Context(ProcessorContext):
+    def __init__(self, metrics: FrozenDict[str, int]) -> None:
+        self._metrics = metrics
+
+    def get_metrics(self) -> Mapping[str, int]:
+        return self._metrics
+
+
+class Server:
+
+    def __init__(self, processor: Processor) -> None:
+        self.processor = processor
+        self.message_queue: queue.Queue[ProcessorMessage] = queue.Queue(maxsize=1000)
+        self.shutdown_event = threading.Event()
+        self.stdin_lock = threading.Lock()
+        self.stdout_lock = threading.Lock()
+
+        # Set up logging
+        self.pid = os.getpid()
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            handlers=[logging.StreamHandler(sys.stderr)],
+        )
+        self.logger = logging.getLogger(__name__)
+        self.logger.info(f"Sidecar server starting with PID {self.pid}")
+
+    def _read_length_prefixed_message(self) -> bytes | None:
+        """Read a length-prefixed message from stdin."""
+        try:
+            with self.stdin_lock:
+                # Read from stdin file descriptor 0 directly
+                length_bytes = os.read(0, 4)
+                if not length_bytes or len(length_bytes) < 4:
+                    self.logger.debug("EOF or incomplete length prefix")
+                    return None
+
+                message_length = struct.unpack(">I", length_bytes)[0]
+                self.logger.debug(f"Reading message of length {message_length}")
+
+                # Read message data
+                message_data = os.read(0, message_length)
+                if not message_data or len(message_data) < message_length:
+                    self.logger.warning(
+                        f"Incomplete message: expected {message_length}, got {len(message_data)}"
+                    )
+                    return None
+
+                return message_data
+
+        except Exception as e:
+            self.logger.error(f"Error reading message: {e}")
+            return None
+
+    def message_reader(self) -> None:
+        self.logger.info("Starting message reader")
+
+        try:
+            while not self.shutdown_event.is_set():
+                message_data = self._read_length_prefixed_message()
+                if message_data is None:
+                    break
+
+                try:
+                    message = pickle.loads(message_data)
+                    self.message_queue.put(message)
+
+                except Exception as e:
+                    self.logger.error(f"Error deserializing message: {e}")
+                    continue
+
+        except Exception as e:
+            self.logger.error(f"Error in message reader: {e}")
+        finally:
+            self.logger.info("Message reader shutting down")
+
+    def _handle_shutdown(self) -> None:
+        """Handle shutdown message."""
+        self.logger.info("Received shutdown message")
+        self.shutdown_event.set()
+
+    def _handle_message(self, message: ProcessorMessage) -> None:
+        self.logger.debug(f"Processing message: {message.operation}")
+
+        try:
+            if message.operation == ProcessorOperation.INITIALIZE:
+                data = message.data
+                assert isinstance(data, InitializeData)
+                self.processor.initialize()
+            elif message.operation == ProcessorOperation.START_WORKUNIT:
+                data = message.data
+                assert isinstance(data, StartWorkunitData)
+                self.processor.start_workunit(
+                    workunit=data.workunit, context=_Context(data.context_metrics)
+                )
+            elif message.operation == ProcessorOperation.COMPLETE_WORKUNIT:
+                data = message.data
+                assert isinstance(data, CompleteWorkunitData)
+                self.processor.complete_workunit(
+                    workunit=data.workunit, context=_Context(data.context_metrics)
+                )
+            elif message.operation == ProcessorOperation.FINISH:
+                data = message.data
+                assert isinstance(data, FinishData)
+                self.processor.finish(
+                    timeout=datetime.timedelta(seconds=data.timeout_seconds or 1.0),
+                    context=_Context(data.context_metrics),
+                )
+            elif message.operation == ProcessorOperation.SHUTDOWN:
+                self._handle_shutdown()
+        except Exception as e:
+            self.logger.error(
+                f"Error whi.e processing work unit message `{message.operation}` (seq id #{message.sequence_id}): {e}"
+            )
+
+        # Signal that the message has been processed.
+        seq_num = message.sequence_id
+        seq_num_bytes = struct.pack(">I", seq_num)
+        with self.stdout_lock:
+            # Write to stdout file descriptor 1 directly
+            os.write(1, seq_num_bytes)
+
+    def process_messages(self) -> None:
+        """Process messages received from the parent process."""
+        self.logger.info("Starting message processor.")
+
+        try:
+            while not self.shutdown_event.is_set():
+                try:
+                    message = self.message_queue.get(timeout=1.0)
+                    self._handle_message(message)
+                except queue.Empty:
+                    continue
+                except Exception as e:
+                    self.logger.error(f"Error processing message: {e}")
+        finally:
+            self.logger.info("Stopped message processor.")
+
+    def run(self) -> None:
+        """Main sidecar server loop."""
+        self.logger.info("Starting sidecar server")
+
+        try:
+            # Start threads
+            reader_thread = threading.Thread(target=self.message_reader, daemon=True)
+            processor_thread = threading.Thread(target=self.process_messages, daemon=True)
+
+            reader_thread.start()
+            processor_thread.start()
+
+            # Wait for shutdown
+            self.shutdown_event.wait()
+
+            # Join threads
+            reader_thread.join(timeout=5.0)
+            processor_thread.join(timeout=5.0)
+
+        except Exception as e:
+            self.logger.error(f"Error in sidecar server: {e}")
+        finally:
+            self.logger.info("Sidecar server shutdown completed")
+
+
+def main(args: Sequence[str]) -> None:
+    parser = argparse.ArgumentParser()
+    OtelParameters.add_options_to_parser(parser)
+    parser.add_argument("--build_root", default=None, action="store")
+    parser.add_argument("--traceparent_env_var", default=None, action="store")
+    parsed_options = parser.parse_args(args)
+    otel_parameters = OtelParameters.from_parsed_options(parsed_options)
+
+    processor = get_processor(
+        span_exporter_name=TracingExporterId.GRPC,
+        otel_parameters=otel_parameters,
+        build_root=Path(parsed_options.build_root),
+        traceparent_env_var=parsed_options.traceparent_env_var,
+        json_file=None,
+    )
+
+    server = Server(processor)
+    server.run()
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/otlp_grpc_subprocess_processor_server.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/otlp_grpc_subprocess_processor_server.py
@@ -50,7 +50,6 @@ class _Context(ProcessorContext):
 
 
 class Server:
-
     def __init__(self, processor: Processor) -> None:
         self.processor = processor
         self.message_queue: queue.Queue[ProcessorMessage] = queue.Queue(maxsize=1000)

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/otlp_grpc_test_server.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/otlp_grpc_test_server.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2025 Shoal Software LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import base64
+import signal
+import sys
+from concurrent import futures
+
+import grpc
+from opentelemetry.proto.collector.trace.v1 import trace_service_pb2_grpc
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+    ExportTraceServiceResponse,
+)
+
+
+class TraceServiceServicer(trace_service_pb2_grpc.TraceServiceServicer):
+    """Receive tracing span export requests for OTLP trace service and pass
+    them to callback."""
+
+    def Export(self, request: ExportTraceServiceRequest, context) -> ExportTraceServiceResponse:
+        encoded_request = base64.b64encode(request.SerializeToString())
+        sys.stdout.buffer.write(encoded_request)
+        sys.stdout.buffer.write(b"\n")
+        sys.stdout.buffer.flush()
+        return ExportTraceServiceResponse()
+
+
+def main() -> None:
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
+
+    def stop_handler(signum, frame):
+        server.stop(None)
+
+    signal.signal(signal.SIGINT, stop_handler)
+    signal.signal(signal.SIGTERM, stop_handler)
+
+    trace_service_pb2_grpc.add_TraceServiceServicer_to_server(TraceServiceServicer(), server)
+
+    port = server.add_insecure_port("127.0.0.1:0")
+    sys.stdout.buffer.write(str(port).encode("utf-8") + b"\n")
+    sys.stdout.buffer.flush()
+
+    server.start()
+    server.wait_for_termination()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/pants_integration_testutil.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/pants_integration_testutil.py
@@ -155,9 +155,9 @@ def run_pants_with_workdir_without_waiting(
         # FIXME: For some reason, Pants's CI adds the coverage file and it is not ignored by default. Why?
         args.append("--pants-ignore=+['.coverage.*', '.python-build-standalone']")
 
-    pantsd_in_command = "--no-pantsd" in command or "--pantsd" in command
-    pantsd_in_config = config and "GLOBAL" in config and "pantsd" in config["GLOBAL"]
-    if not pantsd_in_command and not pantsd_in_config:
+    pantsd_option_present_in_command = "--no-pantsd" in command or "--pantsd" in command
+    pantsd_option_present_in_config = config and "GLOBAL" in config and "pantsd" in config["GLOBAL"]
+    if not pantsd_option_present_in_command and not pantsd_option_present_in_config:
         args.append("--pantsd" if use_pantsd else "--no-pantsd")
 
     # if hermetic:

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/register.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/register.py
@@ -65,8 +65,7 @@ async def telemetry_workunits_callback_factory_request(
 
         # Use subprocess processor for gRPC to avoid fork safety issues.
         if telemetry.exporter == TracingExporterId.GRPC:
-            logger.debug("Using queue processor for gRPC exporter")
-
+            logger.debug("Using subprocess processor for gRPC exporter.")
             processor = SubprocessProcessor(
                 otel_parameters=OtelParameters(
                     endpoint=telemetry.exporter_endpoint,
@@ -86,7 +85,7 @@ async def telemetry_workunits_callback_factory_request(
                 traceparent_env_var=traceparent_env_var,
             )
         else:
-            logger.debug("Using single-threaded processor for non-gRPC exporter")
+            logger.debug("Using single-threaded in-process processor for non-gRPC exporter.")
             otel_processor = get_processor(
                 span_exporter_name=telemetry.exporter,
                 otel_parameters=OtelParameters(

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/requirements.txt
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/requirements.txt
@@ -2,3 +2,4 @@
 opentelemetry-api==1.34.1
 opentelemetry-sdk==1.34.1
 opentelemetry-exporter-otlp==1.34.1
+grpcio==1.73.1

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/single_threaded_processor.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/single_threaded_processor.py
@@ -102,15 +102,11 @@ class SingleThreadedProcessor(Processor):
         self._processor.initialize()
         self._initialize_completed_event.set()
 
-        logger.debug("Work unit processing loop started.")
-
         finish_details: _FinishDetails | None
         while msg := self._queue.get():
             finish_details = self._handle_message(msg)
             if finish_details is not None:
                 break
-
-        logger.debug("Work unit processing loop finished.")
 
         if self._queue.qsize() > 0:
             logger.warning(

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/subprocess_processor.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/subprocess_processor.py
@@ -1,0 +1,399 @@
+# Copyright (C) 2025 Shoal Software LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import datetime
+import logging
+import pickle
+import struct
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Optional
+
+from pants.util.frozendict import FrozenDict
+from shoalsoft.pants_opentelemetry_plugin.message_protocol import (
+    CompleteWorkunitData,
+    FinishData,
+    InitializeData,
+    OtelParameters,
+    ProcessorMessage,
+    ProcessorMessageDataT,
+    ProcessorOperation,
+    StartWorkunitData,
+)
+from shoalsoft.pants_opentelemetry_plugin.processor import (
+    IncompleteWorkunit,
+    Processor,
+    ProcessorContext,
+    Workunit,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SubprocessProcessor(Processor):
+    """A processor that offloads OpenTelemetry operations to a subprocess in
+    order to avoid fork safety issues with the gRPC C libary."""
+
+    def __init__(
+        self,
+        *,
+        otel_parameters: OtelParameters,
+        build_root: str,
+        traceparent_env_var: str | None,
+    ) -> None:
+        self._otel_parameters = otel_parameters
+        self._build_root = build_root
+        self._traceparent_env_var = traceparent_env_var
+
+        self.subprocess: subprocess.Popen | None = None
+        self._writer_lock = threading.Lock()
+        self._sequence_reader_thread: threading.Thread | None = None
+        self._stderr_reader_thread: threading.Thread | None = None
+
+        self._next_sequence_id = 0
+        self._last_processed_sequence_id = 0
+        self._last_processed_sequence_id_cond = threading.Condition()
+
+        self._shutdown_event = threading.Event()
+        self.initialized = False
+
+    def _get_next_sequence_id(self) -> int:
+        self._next_sequence_id += 1
+        return self._next_sequence_id
+
+    def _write_length_prefixed_message(self, message: ProcessorMessage) -> None:
+        """Write a length-prefixed message to the sidecar process."""
+        if self.subprocess is None or self.subprocess.stdin is None:
+            logger.warning("Cannot write message: subprocess stdin not available")
+            return
+
+        encoded_message = pickle.dumps(message)
+
+        try:
+            length = len(encoded_message)
+            length_bytes = struct.pack(">I", length)
+
+            with self._writer_lock:
+                self.subprocess.stdin.write(length_bytes)
+                self.subprocess.stdin.write(encoded_message)
+                self.subprocess.stdin.flush()
+
+            logger.debug(f"Wrote message of length {length}")
+
+        except Exception as e:
+            logger.error(f"Error writing message: {e}")
+            raise
+
+    def _send_msg(self, message: ProcessorMessage) -> None:
+        logger.debug(f"Sending message {message.operation} with sequence ID {message.sequence_id}")
+        if self.subprocess is None or self.subprocess.stdin is None:
+            logger.warning("Cannot enqueue message: sidecar not available")
+            return
+
+        if self._shutdown_event.is_set():
+            logger.debug("Ignoring enqueue after shutdown")
+            return
+
+        try:
+            self._write_length_prefixed_message(message)
+
+        except Exception as e:
+            logger.error(f"Error enqueueing message: {e}")
+
+    def _read_sequence_ids_task(self, started_event: threading.Event) -> None:
+        logger.debug("Starting sequence reader task")
+
+        # Check if we even have a reader
+        if not self.subprocess or not self.subprocess.stdout:
+            logger.error("No reader available!")
+            started_event.set()  # Signal that we've started even if we're failing
+            return
+
+        # Signal that the thread has started
+        started_event.set()
+
+        try:
+            while not self._shutdown_event.is_set():
+
+                try:
+                    # Check if subprocess is still alive before attempting to read
+                    if self.subprocess.poll() is not None:
+                        logger.error(
+                            f"Subprocess has terminated with code {self.subprocess.returncode}"
+                        )
+                        break
+
+                    # Read exactly 4 bytes for sequence ID
+                    seq_num_bytes = self.subprocess.stdout.read(4)
+                    if not seq_num_bytes:
+                        logger.debug("No more data from subprocess")
+                        break
+
+                    if len(seq_num_bytes) != 4:
+                        logger.error(f"Expected 4 bytes, got {len(seq_num_bytes)}")
+                        continue
+
+                except Exception as e:
+                    logger.error(f"Error reading sequence ID: {e}")
+                    # Check if subprocess is still alive
+                    if self.subprocess:
+                        returncode = self.subprocess.poll()
+                        if returncode is not None:
+                            logger.error(f"Subprocess died with returncode {returncode}")
+                            break
+                    continue
+
+                try:
+                    values = struct.unpack(">I", seq_num_bytes)
+                    seq_num: int = values[0]
+                    logger.debug(f"Received sequence ID {seq_num}")
+
+                    with self._last_processed_sequence_id_cond:
+                        if seq_num > self._last_processed_sequence_id:
+                            self._last_processed_sequence_id = seq_num
+                            self._last_processed_sequence_id_cond.notify_all()
+                except Exception as e:
+                    logger.error(f"Error processing sequence ID: {e}")
+                    continue
+
+        except Exception as e:
+            logger.error(f"Error reading sequence IDs: {e}")
+            raise
+        finally:
+            logger.debug("Sequence reader task ending")
+
+    def _read_stderr_task(self, started_event: threading.Event) -> None:
+        """Read stderr from subprocess and log it."""
+        logger.debug("Starting stderr reader task")
+        if not self.subprocess or not self.subprocess.stderr:
+            logger.error("No stderr reader available!")
+            return
+        started_event.set()
+        try:
+            while not self._shutdown_event.is_set():
+                line = self.subprocess.stderr.readline()
+                if not line:
+                    continue
+                # Decode and strip the line, then log it
+                stderr_msg = line.decode("utf-8", errors="replace").rstrip("\n\r")
+                if stderr_msg:  # Only log non-empty lines
+                    logger.debug(f"subprocess stderr: {stderr_msg}")
+        except Exception as e:
+            logger.error(f"Error reading subprocess stderr: {e}")
+        finally:
+            logger.debug("Stderr reader task ending")
+
+    def is_shutdown(self) -> bool:
+        """Check if queue has shutdown."""
+        return self._shutdown_event.is_set()
+
+    def wait_for_shutdown(self, timeout: Optional[float] = None) -> bool:
+        """Wait for queue to shutdown, returns True if shutdown completed."""
+        return self._shutdown_event.wait(timeout=timeout)
+
+    def _spawn_subprocess(self) -> None:
+        """Start the subprocess which will actually invoke gRPC APIs."""
+        logger.debug("Starting subprocess")
+
+        try:
+            args = [
+                sys.executable,
+                str(Path(__file__).parent.joinpath("otlp_grpc_subprocess_processor_server.py")),
+                "--build_root",
+                self._build_root,
+                *(
+                    [f"--traceparent_env_var={self._traceparent_env_var}"]
+                    if self._traceparent_env_var
+                    else []
+                ),
+                *self._otel_parameters.to_args_for_subprocess(),
+            ]
+            self.subprocess = subprocess.Popen(
+                args,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env={
+                    "PYTHONPATH": ":".join(sys.path),
+                    "PYTHONUNBUFFERED": "1",
+                },
+            )
+            logger.debug(f"Subprocess created with PID {self.subprocess.pid}")
+            sequence_reader_started_event = threading.Event()
+            stderr_reader_started_event = threading.Event()
+
+            self._sequence_reader_thread = threading.Thread(
+                target=self._read_sequence_ids_task,
+                args=(sequence_reader_started_event,),
+                daemon=True,
+            )
+            self._stderr_reader_thread = threading.Thread(
+                target=self._read_stderr_task, args=(stderr_reader_started_event,), daemon=True
+            )
+
+            self._sequence_reader_thread.start()
+            self._stderr_reader_thread.start()
+
+            # Wait for threads to start
+            sequence_reader_started_event.wait(timeout=5.0)
+            stderr_reader_started_event.wait(timeout=5.0)
+
+            logger.debug(f"gRPC processor subprocess started with PID {self.subprocess.pid}")
+
+        except Exception as e:
+            logger.error(f"Failed to start subprocess for gRPC OpenTelemetry handler: {e}")
+            raise
+
+    def _kill_subprocess(self) -> None:
+        if not self.subprocess:
+            return
+
+        # Set shutdown event to signal threads to stop
+        self._shutdown_event.set()
+
+        # Join the reader threads
+        if self._sequence_reader_thread and self._sequence_reader_thread.is_alive():
+            self._sequence_reader_thread.join(timeout=5.0)
+        if self._stderr_reader_thread and self._stderr_reader_thread.is_alive():
+            self._stderr_reader_thread.join(timeout=5.0)
+
+        self.subprocess.kill()
+        self.subprocess = None
+
+    def enqueue_message(self, operation: ProcessorOperation, data: ProcessorMessageDataT) -> int:
+        """Create and enqueue a processor message."""
+        message = ProcessorMessage(
+            operation=operation,
+            data=data,
+            sequence_id=self._get_next_sequence_id(),
+        )
+        self._send_msg(message)
+        return message.sequence_id
+
+    def wait_for_sequence_id(self, desired_sequence_id: int) -> None:
+        logger.debug(
+            f"Waiting for sequence ID {desired_sequence_id}, current: {self._last_processed_sequence_id}"
+        )
+
+        # Check if subprocess is still running
+        if self.subprocess:
+            returncode = self.subprocess.poll()
+            if returncode is not None:
+                logger.error(f"Subprocess has exited with code {returncode}")
+                raise RuntimeError(f"Subprocess exited with code {returncode}")
+        else:
+            logger.error("No subprocess found")
+            raise RuntimeError("No subprocess found")
+
+        with self._last_processed_sequence_id_cond:
+            # Wait for the condition with timeout
+            success = self._last_processed_sequence_id_cond.wait_for(
+                lambda: self._last_processed_sequence_id >= desired_sequence_id,
+                timeout=30.0,  # 30 second timeout
+            )
+
+            if not success:
+                logger.error(
+                    f"Timeout waiting for sequence ID {desired_sequence_id}, current: {self._last_processed_sequence_id}"
+                )
+                # Check subprocess status again
+                if self.subprocess:
+                    returncode = self.subprocess.poll()
+                    logger.error(f"After timeout, subprocess returncode: {returncode}")
+                raise RuntimeError(f"Timeout waiting for sequence ID {desired_sequence_id}")
+
+        logger.debug(f"Received sequence ID {desired_sequence_id}")
+
+    def initialize(self) -> None:
+        logger.debug("Initializing SubprocessProcessor")
+
+        self._spawn_subprocess()
+
+        try:
+            initialize_data = InitializeData(
+                otel_parameters=self._otel_parameters,
+                build_root=self._build_root,
+                traceparent_env_var=self._traceparent_env_var,
+            )
+            seq_num = self.enqueue_message(ProcessorOperation.INITIALIZE, initialize_data)
+            self.wait_for_sequence_id(seq_num)
+
+            self.initialized = True
+            logger.info("SubprocessProcessor initialized successfully")
+
+        except Exception as e:
+            logger.error(f"Error initializing SubprocessProcessor: {e}")
+            raise
+
+    def start_workunit(self, workunit: IncompleteWorkunit, *, context: ProcessorContext) -> None:
+        """Enqueue start_workunit message."""
+        if not self.initialized:
+            logger.warning("Cannot start workunit: processor not initialized")
+            return
+
+        try:
+            data = StartWorkunitData(
+                workunit=workunit,
+                context_metrics=FrozenDict(context.get_metrics()),
+            )
+            self.enqueue_message(ProcessorOperation.START_WORKUNIT, data)
+        except Exception as e:
+            logger.error(f"Error starting workunit: {e}")
+
+    def complete_workunit(self, workunit: Workunit, *, context: ProcessorContext) -> None:
+        """Enqueue complete_workunit message."""
+        if not self.initialized:
+            logger.warning("Cannot complete workunit: processor not initialized")
+            return
+
+        try:
+            data = CompleteWorkunitData(
+                workunit=workunit,
+                context_metrics=FrozenDict(context.get_metrics()),
+            )
+            self.enqueue_message(ProcessorOperation.COMPLETE_WORKUNIT, data)
+        except Exception as e:
+            logger.error(f"Error completing workunit: {e}")
+
+    def finish(
+        self, timeout: datetime.timedelta | None = None, *, context: ProcessorContext
+    ) -> None:
+        """Enqueue finish message and monitor shutdown."""
+        logger.info("SubprocessProcessor finish requested")
+
+        if not self.initialized:
+            logger.warning("Cannot finish: processor not initialized")
+            return
+
+        try:
+            timeout_seconds = timeout.total_seconds() if timeout else None
+            data = FinishData(
+                timeout_seconds=timeout_seconds,
+                context_metrics=FrozenDict(context.get_metrics()),
+            )
+
+            finish_seq_num = self.enqueue_message(ProcessorOperation.FINISH, data)
+            self.wait_for_sequence_id(finish_seq_num)
+
+            self._kill_subprocess()
+
+        except Exception as e:
+            logger.error(f"Error finishing SubprocessProcessor: {e}")
+        finally:
+            logger.debug("SubprocessProcessor.finish: Finished")
+        logger.info("SubprocessProcessor finish completed")

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/subprocess_processor_test.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/subprocess_processor_test.py
@@ -1,0 +1,325 @@
+# Copyright (C) 2025 Shoal Software LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import tempfile
+
+import pytest
+
+from shoalsoft.pants_opentelemetry_plugin.message_protocol import OtelParameters
+from shoalsoft.pants_opentelemetry_plugin.processor import IncompleteWorkunit, Level, Workunit
+from shoalsoft.pants_opentelemetry_plugin.subprocess_processor import SubprocessProcessor
+
+
+class MockProcessorContext:
+    """Mock processor context for testing."""
+
+    def __init__(self, metrics=None):
+        self._metrics = metrics or {"test_metric": 42}
+
+    def get_metrics(self):
+        return self._metrics
+
+
+def create_test_otel_parameters():
+    """Create test OTel parameters for subprocess initialization."""
+    return OtelParameters(
+        endpoint="http://localhost:4318/v1/traces",
+        certificate_file=None,
+        client_key_file=None,
+        client_certificate_file=None,
+        headers={},
+        timeout=30,
+        compression=None,
+        insecure=None,
+    )
+
+
+def test_subprocess_processor_initialization():
+    """Test that SubprocessProcessor can be initialized with OTel
+    parameters."""
+    otel_params = create_test_otel_parameters()
+    processor = SubprocessProcessor(
+        otel_parameters=otel_params,
+        build_root="/tmp/test",
+        traceparent_env_var=None,
+    )
+
+    # Verify initial state
+    assert processor._otel_parameters == otel_params
+    assert processor._build_root == "/tmp/test"
+    assert processor._traceparent_env_var is None
+    assert processor.subprocess is None
+    assert not processor.initialized
+    assert not processor.is_shutdown()
+
+
+def test_subprocess_processor_lifecycle():
+    """Test the basic lifecycle of SubprocessProcessor without full subprocess
+    testing."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        otel_params = create_test_otel_parameters()
+        processor = SubprocessProcessor(
+            otel_parameters=otel_params,
+            build_root=temp_dir,
+            traceparent_env_var=None,
+        )
+
+        # Test initial state
+        assert not processor.initialized
+        assert processor.subprocess is None
+        assert not processor.is_shutdown()
+
+        # Note: We skip actual subprocess initialization to avoid test complexity
+        # and focus on testing the processor's state management
+
+
+def test_subprocess_processor_error_handling():
+    """Test error handling in SubprocessProcessor."""
+    otel_params = create_test_otel_parameters()
+    processor = SubprocessProcessor(
+        otel_parameters=otel_params,
+        build_root="/tmp/test",
+        traceparent_env_var=None,
+    )
+
+    # Test operations before initialization
+    context = MockProcessorContext()
+
+    incomplete_workunit = IncompleteWorkunit(
+        name="test_workunit",
+        span_id="test_span_123",
+        parent_ids=(),
+        level=Level.INFO,
+        description="Test workunit description",
+        start_time=datetime.datetime.now(datetime.timezone.utc),
+    )
+
+    # These should not crash but should be no-ops
+    processor.start_workunit(incomplete_workunit, context=context)
+
+    from pants.util.frozendict import FrozenDict
+
+    complete_workunit = Workunit(
+        name="test_workunit",
+        span_id="test_span_123",
+        parent_ids=(),
+        level=Level.INFO,
+        description="Test workunit description",
+        start_time=datetime.datetime.now(datetime.timezone.utc),
+        end_time=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=1),
+        metadata=FrozenDict({}),
+    )
+
+    processor.complete_workunit(complete_workunit, context=context)
+    processor.finish(timeout=datetime.timedelta(seconds=1), context=context)
+
+
+def test_subprocess_processor_shutdown_monitoring():
+    """Test shutdown monitoring functionality."""
+    otel_params = create_test_otel_parameters()
+    processor = SubprocessProcessor(
+        otel_parameters=otel_params,
+        build_root="/tmp/test",
+        traceparent_env_var=None,
+    )
+
+    # Initially not shutdown
+    assert not processor.is_shutdown()
+
+    # Test direct shutdown event setting
+    processor._shutdown_event.set()
+    assert processor.is_shutdown()
+
+    # Test reset
+    processor._shutdown_event.clear()
+    assert not processor.is_shutdown()
+
+
+def test_subprocess_processor_sequence_ids():
+    """Test that sequence IDs are generated correctly."""
+    otel_params = create_test_otel_parameters()
+    processor = SubprocessProcessor(
+        otel_parameters=otel_params,
+        build_root="/tmp/test",
+        traceparent_env_var=None,
+    )
+
+    # Test sequence ID generation
+    seq_id_1 = processor._get_next_sequence_id()
+    seq_id_2 = processor._get_next_sequence_id()
+    seq_id_3 = processor._get_next_sequence_id()
+
+    assert seq_id_1 == 1
+    assert seq_id_2 == 2
+    assert seq_id_3 == 3
+
+
+def test_subprocess_processor_message_creation():
+    """Test message creation without subprocess initialization."""
+    otel_params = create_test_otel_parameters()
+    _ = SubprocessProcessor(
+        otel_parameters=otel_params,
+        build_root="/tmp/test",
+        traceparent_env_var=None,
+    )
+
+    # Test creating messages without initializing
+    context = MockProcessorContext()
+
+    # Create a message manually to test serialization
+    from shoalsoft.pants_opentelemetry_plugin.message_protocol import (
+        InitializeData,
+        ProcessorMessage,
+        ProcessorOperation,
+        StartWorkunitData,
+    )
+
+    # Test InitializeData creation
+    init_data = InitializeData(
+        otel_parameters=otel_params,
+        build_root="/tmp/test",
+        traceparent_env_var=None,
+    )
+    init_message = ProcessorMessage(
+        operation=ProcessorOperation.INITIALIZE, data=init_data, sequence_id=1
+    )
+
+    # Test that message can be created
+    assert init_message.operation == ProcessorOperation.INITIALIZE
+    assert init_message.sequence_id == 1
+    assert isinstance(init_message.data, InitializeData)
+    assert init_message.data.otel_parameters == otel_params
+
+    # Test StartWorkunitData creation
+    incomplete_workunit = IncompleteWorkunit(
+        name="test_workunit",
+        span_id="test_span_123",
+        parent_ids=(),
+        level=Level.INFO,
+        description="Test workunit description",
+        start_time=datetime.datetime.now(datetime.timezone.utc),
+    )
+
+    from pants.util.frozendict import FrozenDict
+
+    workunit_data = StartWorkunitData(
+        workunit=incomplete_workunit,
+        context_metrics=FrozenDict(context.get_metrics()),
+    )
+
+    start_message = ProcessorMessage(
+        operation=ProcessorOperation.START_WORKUNIT, data=workunit_data, sequence_id=2
+    )
+
+    assert start_message.operation == ProcessorOperation.START_WORKUNIT
+    assert start_message.sequence_id == 2
+    assert isinstance(start_message.data, StartWorkunitData)
+    assert start_message.data.workunit.name == "test_workunit"
+
+
+def test_subprocess_processor_sync_methods():
+    """Test sync methods of SubprocessProcessor."""
+    otel_params = create_test_otel_parameters()
+    processor = SubprocessProcessor(
+        otel_parameters=otel_params,
+        build_root="/tmp/test",
+        traceparent_env_var=None,
+    )
+
+    # Test wait_for_shutdown without initialization
+    # Should return False for timeout when not shutdown
+    result = processor.wait_for_shutdown(timeout=0.1)
+    assert result is False
+
+    # Set shutdown manually to test True case
+    processor._shutdown_event.set()
+    result = processor.wait_for_shutdown(timeout=0.1)
+    assert result is True
+
+
+def test_subprocess_processor_with_invalid_build_root():
+    """Test SubprocessProcessor with invalid build root."""
+    otel_params = create_test_otel_parameters()
+    processor = SubprocessProcessor(
+        otel_parameters=otel_params,
+        build_root="/nonexistent/invalid/path",
+        traceparent_env_var=None,
+    )
+
+    # Should be able to create the processor
+    assert processor._build_root == "/nonexistent/invalid/path"
+    assert not processor.initialized
+
+    # Initialization might fail due to invalid path, but shouldn't crash
+    # We'll skip this test since it would require full subprocess setup
+
+
+def test_subprocess_processor_traceparent_env_var():
+    """Test SubprocessProcessor with traceparent environment variable."""
+    otel_params = create_test_otel_parameters()
+    processor = SubprocessProcessor(
+        otel_parameters=otel_params,
+        build_root="/tmp/test",
+        traceparent_env_var="TRACE_PARENT",
+    )
+
+    # Should be able to create the processor
+    assert processor._traceparent_env_var == "TRACE_PARENT"
+    assert not processor.initialized
+
+
+def test_subprocess_processor_thread_lifecycle():
+    """Test the thread lifecycle in SubprocessProcessor."""
+    otel_params = create_test_otel_parameters()
+    processor = SubprocessProcessor(
+        otel_parameters=otel_params,
+        build_root="/tmp/test",
+        traceparent_env_var=None,
+    )
+
+    # Initially threads are not started
+    assert processor._sequence_reader_thread is None
+    assert processor._stderr_reader_thread is None
+
+    # Test that threads are not running
+    assert not processor.is_shutdown()
+
+
+def test_subprocess_processor_sequence_id_increments():
+    """Test that sequence IDs increment correctly."""
+    otel_params = create_test_otel_parameters()
+    processor = SubprocessProcessor(
+        otel_parameters=otel_params,
+        build_root="/tmp/test",
+        traceparent_env_var=None,
+    )
+
+    # Test that sequence IDs start at 0 and increment
+    assert processor._next_sequence_id == 0
+    assert processor._last_processed_sequence_id == 0
+
+    # Get sequence IDs
+    seq1 = processor._get_next_sequence_id()
+    seq2 = processor._get_next_sequence_id()
+    seq3 = processor._get_next_sequence_id()
+
+    assert seq1 == 1
+    assert seq2 == 2
+    assert seq3 == 3
+    assert processor._next_sequence_id == 3
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/workunit_handler.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/workunit_handler.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import datetime
-import logging
 from typing import Any, Mapping
 
 from pants.engine.internals.native_engine import all_counter_names
@@ -29,8 +28,6 @@ from shoalsoft.pants_opentelemetry_plugin.processor import (
     ProcessorContext,
     Workunit,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class _TelemetryContext(ProcessorContext):
@@ -103,10 +100,6 @@ class TelemetryWorkunitsCallback(WorkunitsCallback):
         finished: bool = False,
         **kwargs: Any,
     ) -> None:
-        logger.debug(
-            f"TelemetryWorkunitsCallback called: #completed={len(completed_workunits)}, #started={len(started_workunits)}, finished={finished}"
-        )
-
         telemetry_context = _TelemetryContext(context)
 
         for started_workunit in started_workunits:

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/workunit_handler.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/workunit_handler.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 from typing import Any, Mapping
 
 from pants.engine.internals.native_engine import all_counter_names
@@ -28,6 +29,8 @@ from shoalsoft.pants_opentelemetry_plugin.processor import (
     ProcessorContext,
     Workunit,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class _TelemetryContext(ProcessorContext):
@@ -100,6 +103,10 @@ class TelemetryWorkunitsCallback(WorkunitsCallback):
         finished: bool = False,
         **kwargs: Any,
     ) -> None:
+        logger.debug(
+            f"TelemetryWorkunitsCallback called: #completed={len(completed_workunits)}, #started={len(started_workunits)}, finished={finished}"
+        )
+
         telemetry_context = _TelemetryContext(context)
 
         for started_workunit in started_workunits:


### PR DESCRIPTION
As described in https://github.com/shoalsoft/shoalsoft-pants-opentelemetry-plugin/issues/84, the gRPC C library has documented fork safety issues due to being multi-threaded. It does not operate properly in processes which fork (especially not in a project like Pantsbuild which spawns off build actions regularly). Prior testing was in the context of (contrived) integration tests and did not trigger the fork safety issue. Trying to use this plugin in production during CI did trigger the fork safety issues though.

Solve the issue by offloading work unit processing to a subprocess when the gRPC exporter is configured. The new `SubprocessProcessor` offloads work unit processing to a subprocess. That subprocess is where the gRPC C library is initialized and the subprocess never forks which avoids the fork safety issue.

A prior attempt to solve the problem used `multiprocessing` but that attempt had its own issues with fork safety. In the end, the simpler solution was to just spawn a dedicated Python interpreter and communicate using pickled objects over stdio pipes.