### PR TITLE
fix incomplete option in grpc subprocess

### DIFF
--- a/src/python/shoalsoft/pants_opentelemetry_plugin/message_protocol.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/message_protocol.py
@@ -93,7 +93,7 @@ class OtelParameters:
         parser.add_argument("--headers", default=None, action="store")
         parser.add_argument("--timeout", default=None, type=int, action="store")
         parser.add_argument("--compression", default=None, action="store")
-        parser.add_argument("--insecure", action="store_true")
+        parser.add_argument("--insecure", action=argparse.BooleanOptionalAction)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
The gRPC subprocess needs to support a `--no-insecure` option in addition to an`--insecure` option.