### PR TITLE
update optons now that grpc is no longer supported

### DIFF
--- a/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry_config.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry_config.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import urllib.parse
 from dataclasses import dataclass
 from typing import Mapping
 
@@ -21,10 +22,26 @@ from typing import Mapping
 @dataclass(frozen=True)
 class OtlpParameters:
     endpoint: str | None
+    traces_endpoint: str | None
     certificate_file: str | None
     client_key_file: str | None
     client_certificate_file: str | None
     headers: Mapping[str, str] | None
     timeout: int | None
     compression: str | None
-    insecure: bool | None
+
+    def resolve_traces_endpoint(self) -> str:
+        if self.traces_endpoint:
+            return self.traces_endpoint
+
+        if not self.endpoint:
+            return "http://localhost:4317"
+
+        url = urllib.parse.urlparse(self.endpoint)
+        scheme = url.scheme if url.scheme else "http"
+        path = url.path
+        if not path.endswith("/"):
+            path = path + "/"
+        path = f"{path}/v1/traces"
+        url = url._replace(scheme=scheme, path=path)
+        return url.geturl()

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry_config.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry_config.py
@@ -19,7 +19,7 @@ from typing import Mapping
 
 
 @dataclass(frozen=True)
-class OtelParameters:
+class OtlpParameters:
     endpoint: str | None
     certificate_file: str | None
     client_key_file: str | None

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry_integration_test.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry_integration_test.py
@@ -172,7 +172,7 @@ def do_test_of_otlp_http_exporter(
         result = run_pants_with_workdir(
             [
                 "--shoalsoft-opentelemetry-enabled",
-                f"--shoalsoft-opentelemetry-exporter={TracingExporterId.HTTP.value}",
+                f"--shoalsoft-opentelemetry-exporter={TracingExporterId.OTLP.value}",
                 f"--shoalsoft-opentelemetry-exporter-endpoint=http://127.0.0.1:{server_port}/v1/traces",
                 "list",
                 "otlp-http::",

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry_processor.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry_processor.py
@@ -37,7 +37,7 @@ from opentelemetry.trace.span import NonRecordingSpan, Span, SpanContext
 from opentelemetry.trace.status import StatusCode
 
 from pants.util.frozendict import FrozenDict
-from shoalsoft.pants_opentelemetry_plugin.opentelemetry_config import OtelParameters
+from shoalsoft.pants_opentelemetry_plugin.opentelemetry_config import OtlpParameters
 from shoalsoft.pants_opentelemetry_plugin.processor import (
     IncompleteWorkunit,
     Level,
@@ -87,7 +87,7 @@ def _maybe_add_traces_path(endpoint: str) -> str:
 
 def get_processor(
     span_exporter_name: TracingExporterId,
-    otel_parameters: OtelParameters,
+    otlp_parameters: OtlpParameters,
     build_root: Path,
     traceparent_env_var: str | None,
     json_file: str | None,
@@ -103,13 +103,13 @@ def get_processor(
     span_exporter: SpanExporter
     if span_exporter_name == TracingExporterId.HTTP:
         span_exporter = HttpOTLPSpanExporter(
-            endpoint=_maybe_add_traces_path(otel_parameters.endpoint or "http://localhost:4317"),
-            certificate_file=otel_parameters.certificate_file,
-            client_key_file=otel_parameters.client_key_file,
-            client_certificate_file=otel_parameters.client_certificate_file,
-            headers=dict(otel_parameters.headers) if otel_parameters.headers else None,
-            timeout=otel_parameters.timeout,
-            compression=Compression(otel_parameters.compression),
+            endpoint=_maybe_add_traces_path(otlp_parameters.endpoint or "http://localhost:4317"),
+            certificate_file=otlp_parameters.certificate_file,
+            client_key_file=otlp_parameters.client_key_file,
+            client_certificate_file=otlp_parameters.client_certificate_file,
+            headers=dict(otlp_parameters.headers) if otlp_parameters.headers else None,
+            timeout=otlp_parameters.timeout,
+            compression=Compression(otlp_parameters.compression),
         )
     elif span_exporter_name == TracingExporterId.JSON_FILE:
         json_file_path_str = json_file

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/register.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/register.py
@@ -66,6 +66,7 @@ async def telemetry_workunits_callback_factory_request(
             span_exporter_name=telemetry.exporter,
             otlp_parameters=OtlpParameters(
                 endpoint=telemetry.exporter_endpoint,
+                traces_endpoint=telemetry.exporter_traces_endpoint,
                 certificate_file=telemetry.exporter_certificate_file,
                 client_key_file=telemetry.exporter_client_key_file,
                 client_certificate_file=telemetry.exporter_client_certificate_file,
@@ -74,7 +75,6 @@ async def telemetry_workunits_callback_factory_request(
                 compression=(
                     telemetry.exporter_compression.value if telemetry.exporter_compression else None
                 ),
-                insecure=telemetry.exporter_insecure,
             ),
             build_root=build_root.pathlib_path,
             traceparent_env_var=traceparent_env_var,

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/register.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/register.py
@@ -28,7 +28,7 @@ from pants.engine.unions import UnionRule
 from shoalsoft.pants_opentelemetry_plugin.exception_logging_processor import (
     ExceptionLoggingProcessor,
 )
-from shoalsoft.pants_opentelemetry_plugin.opentelemetry_config import OtelParameters
+from shoalsoft.pants_opentelemetry_plugin.opentelemetry_config import OtlpParameters
 from shoalsoft.pants_opentelemetry_plugin.opentelemetry_processor import get_processor
 from shoalsoft.pants_opentelemetry_plugin.processor import Processor
 from shoalsoft.pants_opentelemetry_plugin.single_threaded_processor import SingleThreadedProcessor
@@ -64,7 +64,7 @@ async def telemetry_workunits_callback_factory_request(
 
         otel_processor = get_processor(
             span_exporter_name=telemetry.exporter,
-            otel_parameters=OtelParameters(
+            otlp_parameters=OtlpParameters(
                 endpoint=telemetry.exporter_endpoint,
                 certificate_file=telemetry.exporter_certificate_file,
                 client_key_file=telemetry.exporter_client_key_file,


### PR DESCRIPTION
Update the supported options and option values now that gRPC is no longer supported:

- Always append `v1/traces` to the regular `[shoalsoft-opentelemetry].exporter_endpoint` option [as per the OpenTelemetry documentation](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp). Add a `[shoalsoft-opentelemetry].exporter_endpoint` option to permit a user to avoid that logic.
- Remove the `insecure` option since that was gRPC-specific.
