### PR TITLE
add support to output links to traces in a tracing system

### DIFF
--- a/src/python/shoalsoft/pants_opentelemetry_plugin/register.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/register.py
@@ -83,6 +83,7 @@ async def telemetry_workunits_callback_factory_request(
             build_root=build_root.pathlib_path,
             traceparent_env_var=traceparent_env_var,
             json_file=telemetry.json_file,
+            trace_link_template=telemetry.trace_link_template,
         )
 
         processor = SingleThreadedProcessor(

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/subsystem.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/subsystem.py
@@ -102,6 +102,24 @@ class TelemetrySubsystem(Subsystem):
         ),
     )
 
+    trace_link_template = StrOption(
+        default=None,
+        help=softwrap(
+            """
+            Log a link to the URL at which the trace will be available in a trace management system. The following
+            replacement variables are available:
+
+            - `{trace_id}` - The OpenTelemetry trace ID
+
+            - `{root_spand_id}` - The span ID of the root span of the trace
+
+            - `{trace_start_ms}` - Start time of the root span in milliseconds since the UNIX epoch
+
+            - `{trace_end_ms}` - End time of the root span in milliseconds since the UNIX epoch
+            """
+        ),
+    )
+
     exporter_endpoint = StrOption(
         default=None,
         help=softwrap(


### PR DESCRIPTION
As described in https://github.com/shoalsoft/shoalsoft-pants-opentelemetry-plugin/issues/103, it is useful to output a link to the trace in the OpenTelemetry-compatible tracing system collecting the work unit spans.

This PR adds a new `[shoalsoft-opentelemetry].trace_link_template` option which, when set, defines a template defining how to output trace links to the log at INFO level.