### PR TITLE
use v0.4.1 for CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Changes since v0.2.0.dev3:
 - Updated docs to show example Honeycomb configuration.
 - Test the plugin with Pants v2.25.2 and v2.26.1.
 
-[Unreleased]: https://github.com/shoalsoft/shoalsoft-pants-opentelemetry-plugin/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/shoalsoft/shoalsoft-pants-opentelemetry-plugin/compare/v0.4.1...HEAD
 [0.4.1]: https://github.com/shoalsoft/shoalsoft-pants-opentelemetry-plugin/releases/tag/v0.4.1
 [0.4.0]: https://github.com/shoalsoft/shoalsoft-pants-opentelemetry-plugin/releases/tag/v0.4.0
 [0.3.0]: https://github.com/shoalsoft/shoalsoft-pants-opentelemetry-plugin/releases/tag/v0.3.0

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -1,10 +1,11 @@
 [GLOBAL]
-plugins.add = ["shoalsoft-pants-opentelemetry-plugin==0.4.0"]
+plugins.add = ["shoalsoft-pants-opentelemetry-plugin==0.4.1"]
 backend_packages.add = ["shoalsoft.pants_opentelemetry_plugin"]
 
 [shoalsoft-opentelemetry]
 enabled = true
 exporter_endpoint = "https://api.honeycomb.io"
+trace_link_template = "https://ui.honeycomb.io/shoalsoft/environments/shoalsoft-pants-opentelemetry-plugin/trace?trace_id={trace_id}&span={root_span_id}"
 
 [shoalsoft-opentelemetry.exporter_headers]
 "x-honeycomb-team" = "%(env.HONEYCOMB_API_KEY)s"


### PR DESCRIPTION
Use v0.4.1 for CI runs and configure `trace_link_template` so that CI logs links to traces in Honeycomb.