### PR TITLE
upgrade to Pants v2.28.0

### DIFF
--- a/3rdparty/python/pants-2.28.lock
+++ b/3rdparty/python/pants-2.28.lock
@@ -16,8 +16,8 @@
 //     "opentelemetry-proto==1.34.1",
 //     "opentelemetry-sdk==1.34.1",
 //     "packaging",
-//     "pantsbuild.pants.testutil==2.28.0rc0",
-//     "pantsbuild.pants==2.28.0rc0",
+//     "pantsbuild.pants.testutil==2.28.0",
+//     "pantsbuild.pants==2.28.0",
 //     "pytest",
 //     "toml==0.10.2",
 //     "types-grpcio==1.0.0.20250703"
@@ -870,23 +870,23 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "21130663aa98ea1105e9457698fc4a5cc3f520bf637adbb65c07171e479317e7",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.28.0rc0/pantsbuild.pants-2.28.0rc0-cp311-cp311-manylinux2014_x86_64.whl"
+              "hash": "3853379d2888f08ac0484c48b4babd28ffe29960a0760d10594b4cdc0806fd58",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.28.0/pantsbuild.pants-2.28.0-cp311-cp311-manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6aa073b8b7e7b7be1085107cc8553da47f8645dd101dc24a4d6128606e0b4768",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.28.0rc0/pantsbuild.pants-2.28.0rc0-cp311-cp311-macosx_13_0_x86_64.whl"
+              "hash": "b75396e2b74e5bd8108867379c14203a3049649292ff6533af9d399a50ddf940",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.28.0/pantsbuild.pants-2.28.0-cp311-cp311-macosx_13_0_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ed3f163e374e26013d804f0e3451c99ca280b605027a94e2c5ecbae715eafe44",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.28.0rc0/pantsbuild.pants-2.28.0rc0-cp311-cp311-macosx_14_0_arm64.whl"
+              "hash": "0bdd8dec07a442c5debbb97d19a9fae20e388a75fb7dd58359aebc47a9828b18",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.28.0/pantsbuild.pants-2.28.0-cp311-cp311-macosx_14_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "68449ca097118e1e4a6f9268dc34debf88a941ba5bffc2c95765be604e1035c7",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.28.0rc0/pantsbuild.pants-2.28.0rc0-cp311-cp311-manylinux2014_aarch64.whl"
+              "hash": "677e5bb4a2ac688b34145e0a4f7c8954587c118db770e0e1e9a860d1fdf59c98",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.28.0/pantsbuild.pants-2.28.0-cp311-cp311-manylinux2014_aarch64.whl"
             }
           ],
           "project_name": "pantsbuild-pants",
@@ -911,37 +911,37 @@
             "typing-extensions~=4.12"
           ],
           "requires_python": "==3.11.*",
-          "version": "2.28.0rc0"
+          "version": "2.28.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4f64f7b7c59b3dcd6226c55d59c90d88cde194aee39a496b44d919d7b0302341",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.28.0rc0/pantsbuild.pants.testutil-2.28.0rc0-py3-none-any.whl"
+              "hash": "22ebb403edbabcd7323b5e0545b9fac7c5d8fd8ca3a3dbb76900acba00b6066b",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.28.0/pantsbuild.pants.testutil-2.28.0-py3-none-any.whl"
             }
           ],
           "project_name": "pantsbuild-pants-testutil",
           "requires_dists": [
-            "pantsbuild.pants==2.28.0rc0",
+            "pantsbuild.pants==2.28.0",
             "pytest<7.1.0,>=6.2.4",
             "toml==0.10.2",
             "types-toml==0.10.8"
           ],
           "requires_python": "==3.11.*",
-          "version": "2.28.0rc0"
+          "version": "2.28.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b447e63a2bc04fd975fc0480b8d5ebf979179e2c0ae203bf1eff9ea20073bc38",
-              "url": "https://files.pythonhosted.org/packages/d6/98/120c3e21bf3fc0ef397a3906465ee9f5c76996c52811e65455eadc12d68a/pbr-7.0.0-py2.py3-none-any.whl"
+              "hash": "32df5156fbeccb6f8a858d1ebc4e465dcf47d6cc7a4895d5df9aa951c712fc35",
+              "url": "https://files.pythonhosted.org/packages/56/c1/7e588435c2394dfded9197a8307417d1ca3b7f49d9bd5b6227d1f3f03ccd/pbr-7.0.1-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cf4127298723dafbce3afd13775ccf3885be5d3c8435751b867f9a6a10b71a39",
-              "url": "https://files.pythonhosted.org/packages/80/88/baf6b45d064271f19fefac7def6a030a893f912f430de0024dd595ced61f/pbr-7.0.0.tar.gz"
+              "hash": "3ecbcb11d2b8551588ec816b3756b1eb4394186c3b689b17e04850dfc20f7e57",
+              "url": "https://files.pythonhosted.org/packages/ad/8d/23253ab92d4731eb34383a69b39568ca63a1685bec1e9946e91a32fc87ad/pbr-7.0.1.tar.gz"
             }
           ],
           "project_name": "pbr",
@@ -949,7 +949,7 @@
             "setuptools"
           ],
           "requires_python": ">=2.6",
-          "version": "7.0.0"
+          "version": "7.0.1"
         },
         {
           "artifacts": [
@@ -1178,13 +1178,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c",
-              "url": "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl"
+              "hash": "2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6",
+              "url": "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422",
-              "url": "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz"
+              "hash": "dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf",
+              "url": "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz"
             }
           ],
           "project_name": "requests",
@@ -1196,8 +1196,8 @@
             "idna<4,>=2.5",
             "urllib3<3,>=1.21.1"
           ],
-          "requires_python": ">=3.8",
-          "version": "2.32.4"
+          "requires_python": ">=3.9",
+          "version": "2.32.5"
         },
         {
           "artifacts": [
@@ -1515,72 +1515,97 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76",
-              "url": "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl"
+              "hash": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548",
+              "url": "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36",
-              "url": "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz"
+              "hash": "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+              "url": "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.9",
-          "version": "4.14.1"
+          "version": "4.15.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "57aaf98b92d72fc70886b5a0e1a1ca52c2320377360341715dd3933a18e827b1",
-              "url": "https://files.pythonhosted.org/packages/89/d5/2626c87c59802863d44d19e35ad16b7e658e4ac190b0dead17ff25460b4c/ujson-5.10.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+              "hash": "4598bf3965fc1a936bd84034312bcbe00ba87880ef1ee33e33c1e88f2c398b49",
+              "url": "https://files.pythonhosted.org/packages/e9/97/bd939bb76943cb0e1d2b692d7e68629f51c711ef60425fa5bb6968037ecd/ujson-5.11.0-pp311-pypy311_pp73-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5b91b5d0d9d283e085e821651184a647699430705b15bf274c7896f23fe9c9d8",
-              "url": "https://files.pythonhosted.org/packages/1f/2b/44d6b9c1688330bf011f9abfdb08911a9dc74f76926dde74e718d87600da/ujson-5.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "4843f3ab4fe1cc596bb7e02228ef4c25d35b4bb0809d6a260852a4bfcab37ba3",
+              "url": "https://files.pythonhosted.org/packages/15/f5/ca454f2f6a2c840394b6f162fff2801450803f4ff56c7af8ce37640b8a2a/ujson-5.11.0-cp311-cp311-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a5b366812c90e69d0f379a53648be10a5db38f9d4ad212b60af00bd4048d0f00",
-              "url": "https://files.pythonhosted.org/packages/23/ec/3c551ecfe048bcb3948725251fb0214b5844a12aa60bee08d78315bb1c39/ujson-5.10.0-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "952c0be400229940248c0f5356514123d428cba1946af6fa2bbd7503395fef26",
+              "url": "https://files.pythonhosted.org/packages/41/b8/ab67ec8c01b8a3721fd13e5cb9d85ab2a6066a3a5e9148d661a6870d6293/ujson-5.11.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f77b74475c462cb8b88680471193064d3e715c7c6074b1c8c412cb526466efe9",
-              "url": "https://files.pythonhosted.org/packages/26/21/a0c265cda4dd225ec1be595f844661732c13560ad06378760036fc622587/ujson-5.10.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "e204ae6f909f099ba6b6b942131cee359ddda2b6e4ea39c12eb8b991fe2010e0",
+              "url": "https://files.pythonhosted.org/packages/43/d9/3f17e3c5773fb4941c68d9a37a47b1a79c9649d6c56aefbed87cc409d18a/ujson-5.11.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "7ec0ca8c415e81aa4123501fee7f761abf4b7f386aad348501a26940beb1860f",
-              "url": "https://files.pythonhosted.org/packages/28/36/8fde862094fd2342ccc427a6a8584fed294055fdee341661c78660f7aef3/ujson-5.10.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+              "hash": "abae0fb58cc820092a0e9e8ba0051ac4583958495bfa5262a12f628249e3b362",
+              "url": "https://files.pythonhosted.org/packages/50/17/30275aa2933430d8c0c4ead951cc4fdb922f575a349aa0b48a6f35449e97/ujson-5.11.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "129e39af3a6d85b9c26d5577169c21d53821d8cf68e079060602e861c6e5da1b",
-              "url": "https://files.pythonhosted.org/packages/29/45/f5f5667427c1ec3383478092a414063ddd0dfbebbcc533538fe37068a0a3/ujson-5.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "d8951bb7a505ab2a700e26f691bdfacf395bc7e3111e3416d325b513eea03a58",
+              "url": "https://files.pythonhosted.org/packages/57/df/b53e747562c89515e18156513cc7c8ced2e5e3fd6c654acaa8752ffd7cd9/ujson-5.11.0-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "502bf475781e8167f0f9d0e41cd32879d120a524b22358e7f205294224c71126",
-              "url": "https://files.pythonhosted.org/packages/8d/9f/4731ef0671a0653e9f5ba18db7c4596d8ecbf80c7922dd5fe4150f1aea76/ujson-5.10.0-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "7e0ec1646db172beb8d3df4c32a9d78015e671d2000af548252769e33079d9a6",
+              "url": "https://files.pythonhosted.org/packages/5d/7c/48706f7c1e917ecb97ddcfb7b1d756040b86ed38290e28579d63bd3fcc48/ujson-5.11.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ab13a2a9e0b2865a6c6db9271f4b46af1c7476bfd51af1f64585e919b7c07fd4",
-              "url": "https://files.pythonhosted.org/packages/90/37/9208e40d53baa6da9b6a1c719e0670c3f474c8fc7cc2f1e939ec21c1bc93/ujson-5.10.0-cp311-cp311-musllinux_1_2_i686.whl"
+              "hash": "86baf341d90b566d61a394869ce77188cc8668f76d7bb2c311d77a00f4bdf844",
+              "url": "https://files.pythonhosted.org/packages/74/cf/209d90506b7d6c5873f82c5a226d7aad1a1da153364e9ebf61eff0740c33/ujson-5.11.0-pp311-pypy311_pp73-manylinux_2_24_i686.manylinux_2_28_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b3cd8f3c5d8c7738257f1018880444f7b7d9b66232c64649f562d7ba86ad4bc1",
-              "url": "https://files.pythonhosted.org/packages/f0/00/3110fd566786bfa542adb7932d62035e0c0ef662a8ff6544b6643b3d6fd7/ujson-5.10.0.tar.gz"
+              "hash": "94fcae844f1e302f6f8095c5d1c45a2f0bfb928cccf9f1b99e3ace634b980a2a",
+              "url": "https://files.pythonhosted.org/packages/7b/c7/fb84f27cd80a2c7e2d3c6012367aecade0da936790429801803fa8d4bffc/ujson-5.11.0-cp311-cp311-manylinux_2_24_i686.manylinux_2_28_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "aa6b3d4f1c0d3f82930f4cbd7fe46d905a4a9205a7c13279789c1263faf06dba",
+              "url": "https://files.pythonhosted.org/packages/8b/7a/2c20dc97ad70cd7c31ad0596ba8e2cf8794d77191ba4d1e0bded69865477/ujson-5.11.0-cp311-cp311-musllinux_1_2_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4b42c115c7c6012506e8168315150d1e3f76e7ba0f4f95616f4ee599a1372bbc",
+              "url": "https://files.pythonhosted.org/packages/94/7e/0519ff7955aba581d1fe1fb1ca0e452471250455d182f686db5ac9e46119/ujson-5.11.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "fac6c0649d6b7c3682a0a6e18d3de6857977378dce8d419f57a0b20e3d775b39",
+              "url": "https://files.pythonhosted.org/packages/c3/15/42b3924258eac2551f8f33fa4e35da20a06a53857ccf3d4deb5e5d7c0b6c/ujson-5.11.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d7c46cb0fe5e7056b9acb748a4c35aa1b428025853032540bb7e41f46767321f",
+              "url": "https://files.pythonhosted.org/packages/da/ea/80346b826349d60ca4d612a47cdf3533694e49b45e9d1c07071bb867a184/ujson-5.11.0-cp311-cp311-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "da473b23e3a54448b008d33f742bcd6d5fb2a897e42d1fc6e7bf306ea5d18b1b",
+              "url": "https://files.pythonhosted.org/packages/ec/ce/48877c6eb4afddfd6bd1db6be34456538c07ca2d6ed233d3f6c6efc2efe8/ujson-5.11.0-cp311-cp311-musllinux_1_2_aarch64.whl"
             }
           ],
           "project_name": "ujson",
           "requires_dists": [],
-          "requires_python": ">=3.8",
-          "version": "5.10.0"
+          "requires_python": ">=3.9",
+          "version": "5.11.0"
         },
         {
           "artifacts": [
@@ -1662,8 +1687,8 @@
     "opentelemetry-proto==1.34.1",
     "opentelemetry-sdk==1.34.1",
     "packaging",
-    "pantsbuild.pants.testutil==2.28.0rc0",
-    "pantsbuild.pants==2.28.0rc0",
+    "pantsbuild.pants.testutil==2.28.0",
+    "pantsbuild.pants==2.28.0",
     "pytest",
     "toml==0.10.2",
     "types-grpcio==1.0.0.20250703"

--- a/3rdparty/python/pants-2.28.txt
+++ b/3rdparty/python/pants-2.28.txt
@@ -1,6 +1,6 @@
 # Pants dependencies
-pantsbuild.pants==2.28.0rc0
-pantsbuild.pants.testutil==2.28.0rc0
+pantsbuild.pants==2.28.0
+pantsbuild.pants.testutil==2.28.0
 
 # OpenTelemetry dependencies
 opentelemetry-api==1.34.1

--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.28.0rc0"
+pants_version = "2.28.0"
 backend_packages.add = [
   "pants.backend.build_files.fmt.black",
   "pants.backend.plugin_development",
@@ -15,7 +15,7 @@ backend_packages.add = [
 interpreter_constraints = ["==3.11.*"]
 enable_resolves = true
 pip_version = "25.0"
-default_resolve = "pants-2.27"
+default_resolve = "pants-2.28"
 
 [python.resolves]
 "pants-2.28" = "3rdparty/python/pants-2.28.lock"

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry_integration_test.py
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/opentelemetry_integration_test.py
@@ -254,7 +254,7 @@ def do_test_of_json_file_exporter(
         )
 
 
-@pytest.mark.parametrize("pants_version_str", ["2.28.0rc0", "2.27.0", "2.26.2", "2.25.3"])
+@pytest.mark.parametrize("pants_version_str", ["2.28.0", "2.27.0", "2.26.2", "2.25.3"])
 def test_opentelemetry_integration(subtests, pants_version_str: str) -> None:
     pants_version = Version(pants_version_str)
     pants_major_minor = f"{pants_version.major}.{pants_version.minor}"


### PR DESCRIPTION
```
Lockfile diff: 3rdparty/python/pants-2.28.lock [pants-2.28]

==                    Upgraded dependencies                     ==

  pantsbuild-pants               2.28.0rc0    -->   2.28.0
  pantsbuild-pants-testutil      2.28.0rc0    -->   2.28.0
  pbr                            7.0.0        -->   7.0.1
  requests                       2.32.4       -->   2.32.5
  typing-extensions              4.14.1       -->   4.15.0
  ujson                          5.10.0       -->   5.11.0
```