### PR TITLE
release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.0] - 2025-09-17
+
+- Test the plugin with Pants v2.29.x.
+- Discontinue testing the plugin with Pants v2.25.x.
+- Use call-by-name syntax for rule invocations.
+
 ## [0.4.1] - 2025-07-24
 
 - Support logging links to traces in a trace collection system via the new `[shoalsoft-opentelemetry].trace_link_template` option.

--- a/src/python/shoalsoft/pants_opentelemetry_plugin/BUILD
+++ b/src/python/shoalsoft/pants_opentelemetry_plugin/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PLUGIN_VERSION = "0.5.0.dev0"
+PLUGIN_VERSION = "0.5.0"
 
 PANTS_MAJOR_MINOR_VERSIONS = ["2.29", "2.28", "2.27", "2.26"]
 


### PR DESCRIPTION
Release v0.5.0 (no changes from v0.5.0.dev0) and update the changelog accordingly.